### PR TITLE
Encounter timeout issue when git diff

### DIFF
--- a/src/foxops/external/git.py
+++ b/src/foxops/external/git.py
@@ -89,7 +89,7 @@ class GitRepository:
             "diff",
             f"{ref_old}..{ref_new}",
             expected_returncodes=frozenset({0, 1}),
-            timeout=30,
+            timeout=120,
         )
 
         output = ""


### PR DESCRIPTION
Encountered below timeout issue, so increase the timeout

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/foxops/reconciliation.py", line 104, in __reconcile_project
    reconciliation_state = await reconcile_project(
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 86, in async_wrapped
    return await fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 48, in __call__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 349, in iter
    return fut.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 51, in __call__
    result = await fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/reconciliation.py", line 276, in reconcile_project
    ) = await update_incarnation_from_git_template_repository(
  File "/usr/local/lib/python3.10/site-packages/foxops/engine/update.py", line 79, in update_incarnation_from_git_template_repository
    return await update_incarnation(
  File "/usr/local/lib/python3.10/site-packages/foxops/engine/update.py", line 147, in update_incarnation
    files_with_conflicts = await diff_patch_func(
  File "/usr/local/lib/python3.10/site-packages/foxops/engine/patching/git_diff_patch.py", line 22, in diff_and_patch
    patch_path = await diff(diff_a_directory, diff_b_directory, logger=logger)
  File "/usr/local/lib/python3.10/site-packages/foxops/engine/patching/git_diff_patch.py", line 84, in diff
    diff_output = await repo.diff("old", "new")
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 87, in diff
    proc = await self._run(
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 65, in _run
    return await git_exec(*args, cwd=self.directory, timeout=timeout, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 30, in git_exec
    return await check_call("git", *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/utils.py", line 44, in check_call
    await asyncio.wait_for(proc.wait(), timeout=timeout)
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 458, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError