### PR TITLE
Change push timeout to 30s

### DIFF
--- a/src/foxops/external/git.py
+++ b/src/foxops/external/git.py
@@ -60,7 +60,7 @@ class GitRepository:
         self.logger = logger.bind(directory=directory.name)
 
     async def _run(
-        self, *args, timeout: int | float | None = 10, **kwargs
+        self, *args, timeout: int | float | None = 30, **kwargs
     ) -> asyncio.subprocess.Process:
         return await git_exec(*args, cwd=self.directory, timeout=timeout, **kwargs)
 


### PR DESCRIPTION
Encountered below issues when pushing code remotely, so increase timeout

Using docker image sha256:94165b305719b0e67c8e76d0ef9bd5d6f9f3104ffe1459a177078df7ec15fe42 for ghcr.io/roche/foxops:v1.6.4 with digest ghcr.io/roche/foxops@sha256:dddc482aed167523f788b8e9fef4ad245607a4d13361395c5a8069383e36c4a1 ...
$ if [[ -z ${FILES_TO_RECONCILE} ]];then # collapsed multi-line command
Files to reconcile: v1/control-planes/dev-feiyun816a/c-cxgdx/edge.yaml
$ if [[ ${#FILES_TO_RECONCILE[@]} == 0 ]];then # collapsed multi-line command
2022-08-16T04:55:03.076569Z [info     ] starting reconciliation        [app] 
2022-08-16T04:55:03.077428Z [info     ] scheduling reconciliation for 1 projects [reconciliation] 
2022-08-16T04:55:09.169009Z [info     ] incarnation has not yet been initialized, initializing it now ... [reconciliation] gitlab_project=PosixPath('roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/edges/c-cxgdx') reconciliation_uuid=adf78c67 target_directory=PosixPath('.')
2022-08-16T04:55:20.594679Z [error    ] killed process as it exceeded the timeout [utils] stderr_buffer= stdout_buffer=
2022-08-16T04:55:20.664819Z [error    ] failed to reconcile project roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/edges/c-cxgdx:  [reconciliation] desired_incarnation_state=DesiredIncarnationStateConfig(gitlab_project=PosixPath('roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/edges/c-cxgdx'), target_directory=PosixPath('.'), template_repository='https://jihulab.com/roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/templates/infrastructure-edge', template_repository_version='v6.4.0', template_data={'cluster_id': 'c-cxgdx', 'cluster_name': 'feiyunedge816c', 'controlplane_cloud_provider': 'ali', 'controlplane_name': 'dev-feiyun816a', 'controlplane_domain': 'dev-feiyun816a.staging.anywhere.roche-digital.cn', 'controlplane_region': 'cn-shanghai', 'controlplane_registry_host': 'registry.dev-feiyun816a.staging.anywhere.roche-digital.cn', 'controlplane_registry_docker_pull_secret_name': 'navify-harbor-control-plane-pull-secret', 'infrastructure_project_url': 'https://jihulab.com/roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/edges/c-cxgdx.git', 'infrastructure_project_secret_name': 'flux-edge-git-pull-secret', 'vault_namespace': 'admin/staging/control-plane-dev-feiyun816a'}, automerge=False)
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/subprocess.py", line 134, in wait
    return await self._transport._wait()
  File "/usr/local/lib/python3.10/asyncio/base_subprocess.py", line 235, in _wait
    return await waiter
asyncio.exceptions.CancelledError
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 456, in wait_for
    return fut.result()
asyncio.exceptions.CancelledError
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/foxops/reconciliation.py", line 104, in __reconcile_project
    reconciliation_state = await reconcile_project(
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 86, in async_wrapped
    return await fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 48, in __call__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.10/site-packages/tenacity/__init__.py", line 349, in iter
    return fut.result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/local/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.10/site-packages/tenacity/_asyncio.py", line 51, in __call__
    result = await fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/reconciliation.py", line 173, in reconcile_project
    return await initialize_incarnation_from_template(
  File "/usr/local/lib/python3.10/site-packages/foxops/reconciliation.py", line 425, in initialize_incarnation_from_template
    await local_incarnation_repository.push_with_potential_retry()
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 124, in push_with_potential_retry
    await self.push()
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 107, in push
    proc = await self._run("push", "--porcelain", "-u", "origin", current_branch)
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 65, in _run
    return await git_exec(*args, cwd=self.directory, timeout=timeout, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/external/git.py", line 30, in git_exec
    return await check_call("git", *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/foxops/utils.py", line 44, in check_call
    await asyncio.wait_for(proc.wait(), timeout=timeout)
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 458, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError
2022-08-16T04:55:20.674755Z [info     ] finished reconciliation        [app] 
2022-08-16T04:55:20.674937Z [info     ] project 'roche/commercial-innovation/navify-anywhere/infrastructure/staging/control-planes/dev-feiyun816a/edges/c-cxgdx' reconciled with state 'failed' [app] category=summary reconciliation_state=<ReconciliationState.FAILED: 4>
Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7fc792bb2b00>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/base_subprocess.py", line 126, in __del__
    self.close()
  File "/usr/local/lib/python3.10/asyncio/base_subprocess.py", line 104, in close
    proto.pipe.close()
  File "/usr/local/lib/python3.10/asyncio/unix_events.py", line 546, in close
    self._close(None)
  File "/usr/local/lib/python3.10/asyncio/unix_events.py", line 570, in _close
    self._loop.call_soon(self._call_connection_lost, exc)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 750, in call_soon
    self._check_closed()
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
Cleaning up project directory and file based variables
00:01
ERROR: Job failed: exit code 2