### PR TITLE
Improve reconciliation status when commit has pipeline which is not c…

### DIFF
--- a/src/foxops/hosters/types.py
+++ b/src/foxops/hosters/types.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from enum import Enum
 from typing import AsyncContextManager, Protocol, TypedDict
 
@@ -52,7 +53,12 @@ class Hoster(Protocol):
         ...
 
     async def get_reconciliation_status(
-        self, incarnation_repository: str, target_directory: str, commit_sha: GitSha, merge_request_id: str | None
+        self,
+        incarnation_repository: str,
+        target_directory: str,
+        commit_sha: GitSha,
+        merge_request_id: str | None,
+        pipeline_timeout: timedelta | None = None,
     ) -> ReconciliationStatus:
         ...
 

--- a/src/foxops/logger.py
+++ b/src/foxops/logger.py
@@ -2,7 +2,12 @@ import logging
 from typing import Sequence
 
 import structlog
-from structlog.contextvars import bind_contextvars, merge_contextvars
+from structlog.contextvars import (
+    bind_contextvars,
+    bound_contextvars,
+    merge_contextvars,
+    unbind_contextvars,
+)
 from structlog.types import Processor
 
 shared_processors: Sequence[Processor] = [
@@ -71,6 +76,8 @@ def setup_logging(level: int | str) -> None:
 
 
 bind = bind_contextvars
+unbind = unbind_contextvars
+bound = bound_contextvars
 
 
 def get_logger(*args, **kwargs) -> structlog.stdlib.BoundLogger:

--- a/src/foxops/routers/incarnations.py
+++ b/src/foxops/routers/incarnations.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from fastapi import APIRouter, Depends, Response, status
 
 from foxops.database import DAL
@@ -281,6 +283,7 @@ async def get_incarnation_with_details(incarnation: Incarnation, hoster: Hoster)
         incarnation.target_directory,
         incarnation.commit_sha,
         incarnation.merge_request_id,
+        pipeline_timeout=timedelta(minutes=1),
     )
 
     return IncarnationWithDetails(

--- a/tests/e2e/hosters/test_gitlab.py
+++ b/tests/e2e/hosters/test_gitlab.py
@@ -1,7 +1,7 @@
-import asyncio
 import base64
 import uuid
 from collections import namedtuple
+from datetime import timedelta
 
 import pytest
 from httpx import AsyncClient, HTTPStatusError
@@ -93,17 +93,13 @@ async def should_return_success_reconciliation_status_for_default_branch_commit_
 async def should_return_pending_reconciliation_status_for_default_branch_commit_with_pending_pipeline(
     test_gitlab_hoster: Hoster, test_repository: RepositoryTestData
 ):
-    # GIVEN
-
-    # Give GitLab some time to create the pipeline
-    await asyncio.sleep(5)
-
     # WHEN
     status = await test_gitlab_hoster.get_reconciliation_status(
         incarnation_repository=test_repository.project["path_with_namespace"],
         target_directory=".",
         commit_sha=test_repository.commit_sha_branch_with_pipeline,
         merge_request_id=None,
+        pipeline_timeout=timedelta(seconds=10),
     )
 
     # THEN


### PR DESCRIPTION
…reated yet

There is a shortcoming in the GitLab API that sometimes for a few seconds the status and last pipeline
of a commit are None while a pipeline is being created - this is the exact same situation as if
there is no pipeline at all.
Therefore, this change implements some checks to clarify if there is potentially a pipeline,
if yes it waits some timeout for the pipeline to be created. However, because of the dynamic nature of pipelines (rules)
there may not be any pipeline - so the timeout is not perfect ...