### PR TITLE
add additional details in the incarnation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 dist/
 .coverage*
 docs/build/
+.idea
+test.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The test suite uses `pytest` as a test runner and it's located under `tests/`.
 The unit tests can be executed by excluding the `e2e` tests:
 
 ```
-pytest -m 'no e2e'
+pytest -m 'not e2e'
 ```
 
 which doesn't require any external database nor GitLab instance.
@@ -22,7 +22,9 @@ To run the `e2e` tests a test GitLab instance needs to be available. It can be s
 docker compose up -d
 ```
 
-And the tests can be run using `pytest`:
+Be aware that an **initial startup of the Gitlab instance can take some time** (5 minutes). Check the logs with `docker-compose logs` to verify it if reached a stable state.
+
+Then, the tests can be run using `pytest`:
 
 ```
 pytest -m 'e2e'
@@ -33,14 +35,14 @@ pytest -m 'e2e'
 The foxops API can be run locally using `uvicorn`:
 
 ```
-uvicorn foxops.__main__:app --host localhost --port 5001 --reload
+uvicorn foxops.__main__:create_app --host localhost --port 5001 --reload --factory
 ```
 
 For this to work foxops needs a few configuration settings to be available.
 These are at least a GitLab address and token. To use the test instance you can run the following
 
 ```
-FOXOPS_STATIC_TOKEN=dummy FOXOPS_GITLAB_ADDRESS=http://localhost:5002/api/v4 FOXOPS_GITLAB_TOKEN=ACCTEST1234567890123 uvicorn foxops.__main__:app --host localhost --port 5001 --reload
+FOXOPS_STATIC_TOKEN=dummy FOXOPS_GITLAB_ADDRESS=http://localhost:5002/api/v4 FOXOPS_GITLAB_TOKEN=ACCTEST1234567890123 uvicorn foxops.__main__:create_app --host localhost --port 5001 --reload --factory
 ```
 
 ### Documentation

--- a/src/foxops/__main__.py
+++ b/src/foxops/__main__.py
@@ -70,9 +70,13 @@ def create_app():
 
     # Add static content
     for frontend_dir in FRONTEND_SUBDIRS:
+        path = settings.frontend_dist_dir / frontend_dir
+        if not path.exists():
+            continue
+
         app.mount(
             f"/{frontend_dir}",
-            StaticFiles(directory=settings.frontend_dist_dir / frontend_dir, html=True),
+            StaticFiles(directory=path, html=True),
             name=f"ui-{frontend_dir}",
         )
 

--- a/src/foxops/__main__.py
+++ b/src/foxops/__main__.py
@@ -72,6 +72,7 @@ def create_app():
     for frontend_dir in FRONTEND_SUBDIRS:
         path = settings.frontend_dist_dir / frontend_dir
         if not path.exists():
+            logger.warning(f"The static asset path at {path} does not exist, skipping ...")
             continue
 
         app.mount(

--- a/src/foxops/engine/models.py
+++ b/src/foxops/engine/models.py
@@ -1,7 +1,6 @@
 import copy
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import MutableMapping
 
 from pydantic import BaseModel, Field
 from ruamel.yaml import YAML
@@ -18,7 +17,7 @@ yaml.default_flow_style = False
 #: Holds the type for all `template_data` dictionary values
 TemplateDataValue = str | int | float
 #: Holds the type for all `template_data` dictionaries
-TemplateData = MutableMapping[str, TemplateDataValue]
+TemplateData = dict[str, TemplateDataValue]
 
 
 @dataclass(frozen=True)

--- a/src/foxops/models/incarnation.py
+++ b/src/foxops/models/incarnation.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+from foxops.engine.models import TemplateDataValue
 from foxops.hosters import ReconciliationStatus
 
 
@@ -29,6 +30,11 @@ class IncarnationBasic(BaseModel):
 
 class IncarnationWithDetails(IncarnationBasic):
     status: ReconciliationStatus
+
+    template_repository: str | None
+    template_repository_version: str | None
+    template_repository_version_hash: str | None
+    template_data: dict[str, TemplateDataValue] | None
 
     class Config:
         orm_mode = True

--- a/src/foxops/routers/incarnations.py
+++ b/src/foxops/routers/incarnations.py
@@ -290,7 +290,9 @@ async def get_incarnation_with_details(incarnation: Incarnation, hoster: Hoster)
         status=reconciliation_status,
     )
 
-    incarnation_state = await hoster.get_incarnation_state(incarnation.incarnation_repository, incarnation.target_directory)
+    incarnation_state = await hoster.get_incarnation_state(
+        incarnation.incarnation_repository, incarnation.target_directory
+    )
     if incarnation_state is not None:
         state = incarnation_state[1]
         response.template_repository = state.template_repository

--- a/src/foxops/routers/incarnations.py
+++ b/src/foxops/routers/incarnations.py
@@ -285,11 +285,20 @@ async def get_incarnation_with_details(incarnation: Incarnation, hoster: Hoster)
         incarnation.merge_request_id,
         pipeline_timeout=timedelta(minutes=1),
     )
-
-    return IncarnationWithDetails(
+    response = IncarnationWithDetails(
         **(await get_incarnation_basic(incarnation, hoster)).dict(),
         status=reconciliation_status,
     )
+
+    incarnation_state = await hoster.get_incarnation_state(incarnation.incarnation_repository, incarnation.target_directory)
+    if incarnation_state is not None:
+        state = incarnation_state[1]
+        response.template_repository = state.template_repository
+        response.template_repository_version = state.template_repository_version
+        response.template_repository_version_hash = state.template_repository_version_hash
+        response.template_data = state.template_data
+
+    return response
 
 
 async def get_incarnation_basic(incarnation: Incarnation, hoster: Hoster) -> IncarnationBasic:

--- a/tests/e2e/test_incarnations_api.py
+++ b/tests/e2e/test_incarnations_api.py
@@ -24,28 +24,36 @@ async def should_initialize_incarnation_in_root_of_empty_repository_when_creatin
     empty_incarnation_gitlab_repository: str,
     mocker: MockFixture,
 ):
+    # GIVEN
+    template_repository_version = "v1.0.0"
+    template_data = {"name": "Jon", "age": "18"}
+
     # WHEN
     response = await api_client.post(
         "/incarnations",
         json={
             "incarnation_repository": empty_incarnation_gitlab_repository,
             "template_repository": template_repository,
-            "template_repository_version": "v1.0.0",
-            "template_data": {"name": "Jon", "age": 18},
+            "template_repository_version": template_repository_version,
+            "template_data": template_data,
         },
     )
     response.raise_for_status()
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": ".",
-        "status": "success",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "success"
+    assert incarnation["template_repository"] == template_repository
+    assert incarnation["template_repository_version"] == template_repository_version
+    assert incarnation["template_data"] == template_data
+
+    assert incarnation["id"] == mocker.ANY
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+    assert incarnation["template_repository_version_hash"] == mocker.ANY
+
     await assert_file_in_repository(
         gitlab_test_client,
         empty_incarnation_gitlab_repository,
@@ -88,14 +96,12 @@ async def should_initialize_incarnation_in_root_of_repository_with_fvars_file_wh
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "success"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     await assert_file_in_repository(
         gitlab_test_client,
         empty_incarnation_gitlab_repository,
@@ -138,14 +144,12 @@ async def should_initialize_incarnation_in_root_of_nonempty_incarnation_in_a_mer
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "pending",
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "pending"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     merge_request_source_branch = await assert_initialization_merge_request_exists(
         gitlab_test_client, empty_incarnation_gitlab_repository
     )
@@ -193,14 +197,11 @@ async def should_initialize_incarnation_in_root_of_nonempty_incarnation_in_defau
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "success"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
     await assert_file_in_repository(
         gitlab_test_client,
         empty_incarnation_gitlab_repository,
@@ -254,14 +255,11 @@ async def should_initialize_incarnation_in_root_of_nonempty_repository_with_fvar
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "pending",
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "pending"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
     merge_request_branch_name = await assert_initialization_merge_request_exists(
         gitlab_test_client, empty_incarnation_gitlab_repository
     )
@@ -321,14 +319,11 @@ async def should_initialize_incarnation_in_subdir_of_empty_repository_when_creat
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": "subdir",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
+    assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert incarnation["target_directory"] == "subdir"
+    assert incarnation["status"] == "success"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
     await assert_file_in_repository(
         gitlab_test_client,
         empty_incarnation_gitlab_repository,
@@ -372,22 +367,20 @@ async def should_initialize_incarnations_in_subdirs_of_empty_repository_when_cre
     subdir2_incarnation = subdir2_response.json()
 
     # THEN
-    assert subdir1_incarnation == {
-        "id": 1,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": "subdir1",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
-    assert subdir2_incarnation == {
-        "id": 2,
-        "incarnation_repository": empty_incarnation_gitlab_repository,
-        "target_directory": "subdir2",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
+    assert subdir1_incarnation["id"] == 1
+    assert subdir1_incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert subdir1_incarnation["target_directory"] == "subdir1"
+    assert subdir1_incarnation["status"] == "success"
+    assert subdir1_incarnation["commit_url"] == mocker.ANY
+    assert subdir1_incarnation["merge_request_url"] == mocker.ANY
+
+    assert subdir2_incarnation["id"] == 2
+    assert subdir2_incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
+    assert subdir2_incarnation["target_directory"] == "subdir2"
+    assert subdir2_incarnation["status"] == "success"
+    assert subdir2_incarnation["commit_url"] == mocker.ANY
+    assert subdir2_incarnation["merge_request_url"] == mocker.ANY
+
     await assert_file_in_repository(
         gitlab_test_client,
         empty_incarnation_gitlab_repository,
@@ -424,14 +417,12 @@ async def should_create_merge_request_when_file_changed_during_update(
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": incarnation_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "pending",
-    }
+    assert incarnation["incarnation_repository"] == incarnation_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "pending"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     update_branch_name = await assert_update_merge_request_exists(gitlab_test_client, incarnation_repository)
     await assert_file_in_repository(
         gitlab_test_client,
@@ -475,14 +466,12 @@ async def should_create_merge_request_when_file_changed_with_fvars_during_update
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": incarnation_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "pending",
-    }
+    assert incarnation["incarnation_repository"] == incarnation_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "pending"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     update_branch_name = await assert_update_merge_request_exists(gitlab_test_client, incarnation_repository)
     await assert_file_in_repository(
         gitlab_test_client,
@@ -528,14 +517,12 @@ async def should_present_conflict_in_merge_request_when_updating(
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": incarnation_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "pending",
-    }
+    assert incarnation["incarnation_repository"] == incarnation_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "pending"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     await assert_update_merge_request_with_conflicts_exists(
         gitlab_test_client,
         incarnation_repository,
@@ -565,14 +552,12 @@ async def should_automerge_merge_request_when_flag_is_true(
     incarnation = response.json()
 
     # THEN
-    assert incarnation == {
-        "id": 1,
-        "incarnation_repository": incarnation_repository,
-        "target_directory": ".",
-        "commit_url": mocker.ANY,
-        "merge_request_url": mocker.ANY,
-        "status": "success",
-    }
+    assert incarnation["incarnation_repository"] == incarnation_repository
+    assert incarnation["target_directory"] == "."
+    assert incarnation["status"] == "success"
+    assert incarnation["commit_url"] == mocker.ANY
+    assert incarnation["merge_request_url"] == mocker.ANY
+
     await assert_file_in_repository(
         gitlab_test_client,
         incarnation_repository,


### PR DESCRIPTION
... about the used template repository and version. Those details are only available when fetching individual incarnations (to prevent performance issues, as additional API calls are required to fetch them)

![image](https://user-images.githubusercontent.com/3579167/186015616-2d414d09-0ec7-4342-9d34-1d0b6d305579.png)
