### PR TITLE
fix handling of conflicts with incarnations in subdirectories

### DIFF
--- a/src/foxops/engine/__main__.py
+++ b/src/foxops/engine/__main__.py
@@ -230,7 +230,7 @@ def cmd_update(
     )
 
     try:
-        files_with_conflicts = asyncio.run(
+        _, _, files_with_conflicts = asyncio.run(
             update_incarnation_from_git_template_repository(
                 template_git_repository=Path(incarnation_state.template_repository),
                 update_template_repository_version=update_repository_version,

--- a/src/foxops/engine/__main__.py
+++ b/src/foxops/engine/__main__.py
@@ -232,8 +232,7 @@ def cmd_update(
     try:
         files_with_conflicts = asyncio.run(
             update_incarnation_from_git_template_repository(
-                template_git_root_dir=Path(incarnation_state.template_repository),
-                update_template_repository=str(incarnation_state.template_repository),
+                template_git_repository=Path(incarnation_state.template_repository),
                 update_template_repository_version=update_repository_version,
                 update_template_data=merged_template_data,
                 incarnation_root_dir=incarnation_dir,

--- a/src/foxops/engine/update.py
+++ b/src/foxops/engine/update.py
@@ -12,8 +12,7 @@ logger = get_logger(__name__)
 
 
 async def update_incarnation_from_git_template_repository(
-    template_git_root_dir: Path,
-    update_template_repository: str,
+    template_git_repository: Path,
     update_template_repository_version: str,
     update_template_data: TemplateData,
     incarnation_root_dir: Path,
@@ -23,18 +22,18 @@ async def update_incarnation_from_git_template_repository(
     current_incarnation_state_path = incarnation_root_dir / ".fengine.yaml"
     current_incarnation_state = load_incarnation_state(current_incarnation_state_path)
 
-    with TemporaryDirectory() as template_root_dir, TemporaryDirectory() as updated_template_root_dir:
+    with TemporaryDirectory() as original_template_root_dir, TemporaryDirectory() as updated_template_root_dir:
         logger.debug(
             f"creating git worktree from current template repository "
-            f"(version: {current_incarnation_state.template_repository_version_hash}) at {template_root_dir}"
+            f"(version: {current_incarnation_state.template_repository_version_hash}) at {original_template_root_dir}"
         )
         await utils.check_call(
             "git",
             "worktree",
             "add",
-            template_root_dir,
+            original_template_root_dir,
             current_incarnation_state.template_repository_version_hash,
-            cwd=template_git_root_dir,
+            cwd=template_git_repository,
         )
         logger.debug(
             f"creating git worktree from updated template repository "
@@ -46,26 +45,24 @@ async def update_incarnation_from_git_template_repository(
             "add",
             updated_template_root_dir,
             update_template_repository_version,
-            cwd=template_git_root_dir,
+            cwd=template_git_repository,
         )
 
         return await update_incarnation(
-            template_root_dir=Path(template_root_dir),
-            update_template_root_dir=Path(updated_template_root_dir),
-            update_template_repository=update_template_repository,
-            update_template_repository_version=update_template_repository_version,
-            update_template_data=update_template_data,
+            original_template_root_dir=Path(original_template_root_dir),
+            updated_template_root_dir=Path(updated_template_root_dir),
+            updated_template_repository_version=update_template_repository_version,
+            updated_template_data=update_template_data,
             incarnation_root_dir=incarnation_root_dir,
             diff_patch_func=diff_patch_func,
         )
 
 
 async def update_incarnation(
-    template_root_dir: Path,
-    update_template_root_dir: Path,
-    update_template_repository: str,
-    update_template_repository_version: str,
-    update_template_data: TemplateData,
+    original_template_root_dir: Path,
+    updated_template_root_dir: Path,
+    updated_template_repository_version: str,
+    updated_template_data: TemplateData,
     incarnation_root_dir: Path,
     diff_patch_func,
 ) -> tuple[bool, IncarnationState, list[Path] | None]:
@@ -77,11 +74,11 @@ async def update_incarnation(
     with TemporaryDirectory() as tmp_pristine_incarnation_dir, TemporaryDirectory() as tmp_updated_incarnation_dir:
         logger.debug(
             "initialize pristine incarnation from current incarnation state",
-            template_dir=template_root_dir,
+            template_dir=original_template_root_dir,
             incarnation_dir=tmp_pristine_incarnation_dir,
         )
         await _initialize_incarnation(
-            template_root_dir=template_root_dir,
+            template_root_dir=original_template_root_dir,
             template_repository=current_incarnation_state.template_repository,
             template_repository_version=current_incarnation_state.template_repository_version,
             template_data=current_incarnation_state.template_data,
@@ -90,15 +87,15 @@ async def update_incarnation(
 
         logger.debug(
             "initialize new incarnation from update incarnation state",
-            template_dir=update_template_root_dir,
+            template_dir=updated_template_root_dir,
             incarnation_dir=tmp_updated_incarnation_dir,
         )
         updated_incarnation_state = await _initialize_incarnation(
-            template_root_dir=update_template_root_dir,
-            template_repository=update_template_repository,
-            template_repository_version=update_template_repository_version,
+            template_root_dir=updated_template_root_dir,
+            template_repository=current_incarnation_state.template_repository,
+            template_repository_version=updated_template_repository_version,
             template_data=merge_template_data_with_fvars(
-                update_template_data,
+                updated_template_data,
                 incarnation_root_dir,
             ),
             incarnation_root_dir=Path(tmp_updated_incarnation_dir),

--- a/src/foxops/reconciliation/update.py
+++ b/src/foxops/reconciliation/update.py
@@ -87,8 +87,7 @@ async def update_incarnation(
             updated_incarnation_state,
             files_with_conflicts,
         ) = await fengine.update_incarnation_from_git_template_repository(
-            template_git_root_dir=local_template_repository.directory,
-            update_template_repository=incarnation_state_before_update.template_repository,
+            template_git_repository=local_template_repository.directory,
             update_template_repository_version=template_repository_version_update,
             update_template_data=template_data_update,
             incarnation_root_dir=(local_incarnation_repository.directory / incarnation.target_directory),

--- a/tests/engine/test_update.py
+++ b/tests/engine/test_update.py
@@ -105,7 +105,9 @@ async def test_diff_and_patch_no_change_when_updating_to_template_version_with_i
     # GIVEN
     template_directory = tmp_path / "template"
     template_directory.mkdir()
-    (template_directory / "myfile.txt").write_text(
+
+    (template_directory / "template").mkdir()
+    (template_directory / "template" / "myfile.txt").write_text(
         """r1 {...}
 
 r2 {...}
@@ -127,7 +129,7 @@ r2 {...}
     # same change in template and incarnation
     updated_template_directory = tmp_path / "updated-template"
     shutil.copytree(template_directory, updated_template_directory)
-    (updated_template_directory / "myfile.txt").write_text(
+    (updated_template_directory / "template" / "myfile.txt").write_text(
         """r1 {...}
 
 rnew {...}
@@ -144,6 +146,87 @@ r2 {...}
 """
     )
     await init_repository(incarnation_directory)
+
+    await update_incarnation(
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=updated_template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data=incarnation_state.template_data,
+        incarnation_root_dir=incarnation_directory,
+        diff_patch_func=diff_patch_func,
+    )
+
+    # THEN
+    assert (incarnation_directory / "myfile.txt").read_text() == (
+        """r1 {...}
+
+rnew {...}
+
+r2 {...}
+"""
+    )
+
+
+@pytest.mark.parametrize("diff_patch_func", [diff_and_patch])
+async def test_diff_and_patch_no_change_when_updating_to_template_version_with_identical_change_in_subdirectory(
+    diff_patch_func,
+    tmp_path,
+):
+    """
+    Verify that no change is being made to the incarnation repository when updating to a template version
+    which contains the same changes as the incarnation.
+
+    This test verifies things are working correctly when the incarnation was initialized in a subdirectory
+    of a git repository.
+    """
+    # GIVEN
+    template_directory = tmp_path / "template"
+    template_directory.mkdir()
+
+    (template_directory / "template").mkdir()
+    (template_directory / "template" / "myfile.txt").write_text(
+        """r1 {...}
+
+r2 {...}
+"""
+    )
+    await init_repository(tmp_path)
+
+    incarnation_repository_directory = tmp_path / "incarnation"
+    incarnation_repository_directory.mkdir()
+
+    incarnation_directory = incarnation_repository_directory / "subdir"
+    incarnation_directory.mkdir()
+
+    incarnation_state = await initialize_incarnation(
+        template_root_dir=template_directory,
+        template_repository="any-repository-url",
+        template_repository_version="any-version",
+        template_data={},
+        incarnation_root_dir=incarnation_directory,
+    )
+    await init_repository(incarnation_repository_directory)
+
+    # WHEN
+    # same change in template and incarnation
+    updated_template_directory = tmp_path / "updated-template"
+    shutil.copytree(template_directory, updated_template_directory)
+    (updated_template_directory / "template" / "myfile.txt").write_text(
+        """r1 {...}
+
+rnew {...}
+
+r2 {...}
+"""
+    )
+    (incarnation_directory / "myfile.txt").write_text(
+        """r1 {...}
+
+rnew {...}
+
+r2 {...}
+"""
+    )
 
     await update_incarnation(
         original_template_root_dir=template_directory,

--- a/tests/engine/test_update.py
+++ b/tests/engine/test_update.py
@@ -146,11 +146,10 @@ r2 {...}
     await init_repository(incarnation_directory)
 
     await update_incarnation(
-        template_root_dir=template_directory,
-        update_template_root_dir=updated_template_directory,
-        update_template_repository=incarnation_state.template_repository,
-        update_template_repository_version=incarnation_state.template_repository_version,
-        update_template_data=incarnation_state.template_data,
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=updated_template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data=incarnation_state.template_data,
         incarnation_root_dir=incarnation_directory,
         diff_patch_func=diff_patch_func,
     )
@@ -218,11 +217,10 @@ c
 
     # WHEN
     update_performed, _, files_with_conflicts = await update_incarnation(
-        template_root_dir=template_directory,
-        update_template_root_dir=updated_template_directory,
-        update_template_repository=incarnation_state.template_repository,
-        update_template_repository_version=incarnation_state.template_repository_version,
-        update_template_data=incarnation_state.template_data,
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=updated_template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data=incarnation_state.template_data,
         incarnation_root_dir=incarnation_directory,
         diff_patch_func=diff_patch_func,
     )
@@ -297,11 +295,10 @@ mychange
     await init_repository(incarnation_directory)
 
     await update_incarnation(
-        template_root_dir=template_directory,
-        update_template_root_dir=updated_template_directory,
-        update_template_repository=incarnation_state.template_repository,
-        update_template_repository_version=incarnation_state.template_repository_version,
-        update_template_data=incarnation_state.template_data,
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=updated_template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data=incarnation_state.template_data,
         incarnation_root_dir=incarnation_directory,
         diff_patch_func=diff_patch_func,
     )
@@ -371,11 +368,10 @@ variables:
     await init_repository(incarnation_directory)
 
     await update_incarnation(
-        template_root_dir=template_directory,
-        update_template_root_dir=template_directory,
-        update_template_repository=incarnation_state.template_repository,
-        update_template_repository_version=incarnation_state.template_repository_version,
-        update_template_data={},
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data={},
         incarnation_root_dir=incarnation_directory,
         diff_patch_func=diff_patch_func,
     )
@@ -424,11 +420,10 @@ async def test_diff_and_patch_success_when_deleting_file_in_template(
     await utils.check_call("git", "commit", "-am", "Initial commit", cwd=str(incarnation_directory))
 
     await update_incarnation(
-        template_root_dir=template_directory,
-        update_template_root_dir=updated_template_directory,
-        update_template_repository=incarnation_state.template_repository,
-        update_template_repository_version=incarnation_state.template_repository_version,
-        update_template_data=incarnation_state.template_data,
+        original_template_root_dir=template_directory,
+        updated_template_root_dir=updated_template_directory,
+        updated_template_repository_version=incarnation_state.template_repository_version,
+        updated_template_data=incarnation_state.template_data,
         incarnation_root_dir=incarnation_directory,
         diff_patch_func=diff_patch_func,
     )


### PR DESCRIPTION
PR also contains a few other renames and fixes. The latter namely are
* `fengine update` command will no longer incorrectly report conflicts when there were none
* the `test_diff_and_patch_no_change_when_updating_to_template_version_with_identical_change` didn't test what it should, as it was creating an empty template
* fix for #145 - changes are mainly in `git_diff_patch.py`, where some paths were mixed up