### PR TITLE
Use port 8000 rather than 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,5 @@ COPY ./alembic.ini alembic.ini
 COPY ./alembic/versions alembic/versions
 COPY ./alembic/env.py alembic/env.py
 
-EXPOSE 80
-CMD [ "uvicorn", "foxops.__main__:create_app", "--factory", "--proxy-headers", "--host", "0.0.0.0", "--port", "80" ]
+EXPOSE 8000
+CMD [ "uvicorn", "foxops.__main__:create_app", "--factory", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000" ]


### PR DESCRIPTION
This fix is to close: https://github.com/Roche/foxops/issues/178

When deploying Foxops to Alicloud ACK, encountered below issues. The issue is due to the user does not have privileges to bind the port 80. Therefore, it's necessary to use a port > 1000

INFO: Started server process [1]
INFO: Waiting for application startup.
2022-10-23 13:23:13 [info ] Started foxops 0.0.0 [foxops.main]
2022-10-23 13:23:13 [info ] Application startup complete. [uvicorn.error]
2022-10-23 13:23:13 [error ] [Errno 13] error while attempting to bind on address ('0.0.0.0', 80): permission denied [uvicorn.error]
2022-10-23 13:23:13 [info ] Waiting for application shutdown. [uvicorn.error]
2022-10-23 13:23:13 [info ] Application shutdown complete. [uvicorn.error]