### PR TITLE
Gitlab remote

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,25 @@
+# by default gitlab will run on localhost (i.e. same host where tests are run) listening on port 5002
+# this can be overriden with environment variables: GITLAB_HOST & GITLAB_PORT & GITLAB_ADDRESS
+# Eg: 
+# env GITLAB_HOST="myserver.example.com" GITLAB_PORT="8002" docker-compose up -d
+# env GITLAB_HOST="myserver.example.com" GITLAB_PORT="8002" ./script/await-healthy.sh
+# env GITLAB_ADDRESS="http://myserver.example.com:8002/api/v4" poetry run pytest -m 'e2e'
+
 version: '3'
 
 services:
+  init-rb:
+    image: alpine
+    volumes:
+      - config-ee:/etc/gitlab
+      - ${PWD}/scripts/gitlab.rb:/src.rb
+    command: sh -c 'cat /src.rb | sed -e "s/_GITLAB_HOST_/${GITLAB_HOST:-127.0.0.1}/" -e "s/_GITLAB_PORT_/${GITLAB_PORT:-5002}/" > /etc/gitlab/gitlab.rb'
+    
   gitlab-ee:
     image: gitlab/gitlab-ee:${GITLAB_EE_VERSION:-latest}
     restart: always
     ports:
-      - 5002:80
+      - ${GITLAB_PORT:-5002}:80
     environment:
       GITLAB_ROOT_PASSWORD: adminadmin
     labels:
@@ -15,11 +29,13 @@ services:
       - logs-ee:/var/log/gitlab
       - data-ee:/var/opt/gitlab
       - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh:Z
-      - ${PWD}/scripts/gitlab.rb:/etc/gitlab/gitlab.rb:ro
     healthcheck:
       test: /healthcheck-and-setup.sh
       interval: 10s
       timeout: 2m
+    depends_on:
+      init-rb:
+        condition: service_completed_successfully
 
 volumes:
   config-ce:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,6 @@
 version: '3'
 
 services:
-  init-rb:
-    image: alpine
-    volumes:
-      - config-ee:/etc/gitlab
-      - ${PWD}/scripts/gitlab.rb:/src.rb
-    command: sh -c 'cat /src.rb | sed -e "s/_GITLAB_HOST_/${GITLAB_HOST:-127.0.0.1}/" -e "s/_GITLAB_PORT_/${GITLAB_PORT:-5002}/" > /etc/gitlab/gitlab.rb'
-    
   gitlab-ee:
     image: gitlab/gitlab-ee:${GITLAB_EE_VERSION:-latest}
     restart: always
@@ -22,6 +15,9 @@ services:
       - ${GITLAB_PORT:-5002}:80
     environment:
       GITLAB_ROOT_PASSWORD: adminadmin
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url "http://${GITLAB_HOST:-127.0.0.1}:${GITLAB_PORT:-5002}"
+        nginx['listen_port'] = 80
     labels:
       foxops-gitlab/owned: ''
     volumes:
@@ -33,9 +29,6 @@ services:
       test: /healthcheck-and-setup.sh
       interval: 10s
       timeout: 2m
-    depends_on:
-      init-rb:
-        condition: service_completed_successfully
 
 volumes:
   config-ce:

--- a/scripts/await-healthy.sh
+++ b/scripts/await-healthy.sh
@@ -11,5 +11,5 @@ echo
 echo 'GitLab is healthy'
 
 # Print the version, since it is useful debugging information.
-curl --silent --show-error --header 'Authorization: Bearer ACCTEST1234567890123' http://127.0.0.1:5002/api/v4/version
+curl --silent --show-error --header 'Authorization: Bearer ACCTEST1234567890123' http://${GITLAB_HOST:-127.0.0.1}:${GITLAB_PORT:-5002}/api/v4/version
 echo

--- a/scripts/gitlab.rb
+++ b/scripts/gitlab.rb
@@ -1,2 +1,0 @@
-external_url "http://_GITLAB_HOST_:_GITLAB_PORT_"
-nginx['listen_port'] = 80

--- a/scripts/gitlab.rb
+++ b/scripts/gitlab.rb
@@ -1,3 +1,2 @@
-# This has to match the `docker-compose.yml` configuration.
-external_url "http://127.0.0.1:5002"
+external_url "http://_GITLAB_HOST_:_GITLAB_PORT_"
 nginx['listen_port'] = 80


### PR DESCRIPTION
This PR gives the possibility to run the test gitlab instance on a remote host rather than localhost. This is convenient if for any reason one cannot run unit tests and gitlab on the same host, or wants to leverage an existing gitlab instance.
Configuration is done through environment variables. If not set behavior is unchanged (i.e. running on 127.0.0.1:5002)

to start the instance:
`ssh myserver.example.com`
`export GITLAB_HOST="myserver.example.com"`
`export GITLAB_PORT="8002"`
`docker-compose up -d`
`./script/await-healthy.sh`

start unit test:
`ssh testserver.example.com`
`env GITLAB_ADDRESS="http://myserver.example.com:8002/api/v4" poetry run pytest -m 'e2e'`