### PR TITLE
close unused file created by mkstemp

### DIFF
--- a/src/foxops/engine/patching/git_diff_patch.py
+++ b/src/foxops/engine/patching/git_diff_patch.py
@@ -1,5 +1,5 @@
-import os
 import filecmp
+import os
 import re
 import shutil
 import typing

--- a/src/foxops/engine/patching/git_diff_patch.py
+++ b/src/foxops/engine/patching/git_diff_patch.py
@@ -1,3 +1,4 @@
+import os
 import filecmp
 import re
 import shutil
@@ -84,7 +85,8 @@ async def diff(old_directory: Path, new_directory: Path) -> Path | None:
             return None
 
         logger.debug("create patch from git diff", diff_output=diff_output)
-        _, patch_path = mkstemp(prefix="fengine-update-", suffix=".patch")
+        fd, patch_path = mkstemp(prefix="fengine-update-", suffix=".patch")
+        os.close(fd)
 
         (p := Path(patch_path)).write_text(diff_output)
         return p


### PR DESCRIPTION
This is a bug fix PR. In **git_diff_patch.py**, `mkstemp` is used for creating a temporary file for git diff patch but the file is never closed. 
This is especially causing a crash on Windows as the patch temp file cannot be deleted with a system error: `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`