### PR TITLE
removing the deprecated "status" field in incarnation details

### DIFF
--- a/src/foxops/hosters/__init__.py
+++ b/src/foxops/hosters/__init__.py
@@ -3,5 +3,4 @@ from foxops.hosters.types import (  # noqa: F401
     Hoster,
     HosterSettings,
     MergeRequestId,
-    ReconciliationStatus,
 )

--- a/src/foxops/hosters/gitlab/gitlab.py
+++ b/src/foxops/hosters/gitlab/gitlab.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import shutil
 from contextlib import asynccontextmanager
@@ -28,10 +27,9 @@ from foxops.hosters.types import (
     Hoster,
     MergeRequestId,
     MergeRequestStatus,
-    ReconciliationStatus,
     RepositoryMetadata,
 )
-from foxops.logger import bound, get_logger
+from foxops.logger import get_logger
 
 #: Holds the module logger
 logger = get_logger(__name__)
@@ -283,118 +281,6 @@ class GitLab(Hoster):
 
         return await __merge(merge_request)
 
-    async def get_reconciliation_status(
-        self,
-        incarnation_repository: str,
-        target_directory: str,
-        commit_sha: GitSha,
-        merge_request_id: str | None,
-        pipeline_timeout: timedelta | None = None,
-    ) -> ReconciliationStatus:
-        if pipeline_timeout is None:
-            pipeline_timeout = timedelta()
-
-        async def _get_commit_status(commit_sha: GitSha, pipeline_timeout: timedelta) -> ReconciliationStatus:
-            response = await self.client.get(
-                f"/projects/{quote_plus(incarnation_repository)}/repository/commits/{commit_sha}"
-            )
-            response.raise_for_status()
-            commit: Commit = response.json()
-
-            with bound(commit=commit):
-                if commit["status"] is None and commit["last_pipeline"] is None:
-                    has_pipeline_config = await self._has_gitlab_ci_configuration(incarnation_repository, commit_sha)
-                    if has_pipeline_config:
-                        if pipeline_timeout.total_seconds() > 0:
-                            logger.debug(
-                                f"Reconciliation status: no commit status and no pipeline, and pipeline_timeout "
-                                f"is {pipeline_timeout.total_seconds()} seconds, sleeping 1 second and retry"
-                            )
-                            await asyncio.sleep(1)
-                            return await _get_commit_status(commit_sha, pipeline_timeout - timedelta(seconds=1))
-
-                    logger.debug(
-                        "Reconciliation status: no commit status and no pipeline, assuming SUCCESS",
-                        has_pipeline_config=has_pipeline_config,
-                    )
-                    return ReconciliationStatus.SUCCESS
-
-                if commit["status"] == "success":
-                    logger.debug("Reconciliation status: commit status is success, returning SUCCESS")
-                    return ReconciliationStatus.SUCCESS
-
-                if commit["status"] in {"created", "pending", "running"}:
-                    logger.debug(f"Reconciliation status: commit status is {commit['status']}, returning PENDING")
-                    return ReconciliationStatus.PENDING
-
-                if commit["status"] in {"failed", "canceled"}:
-                    logger.debug(f"Reconciliation status: commit status is {commit['status']}, returning FAILED")
-                    return ReconciliationStatus.FAILED
-
-                logger.error(
-                    f"Incarnation '{incarnation_repository}' / '{target_directory}' has an unknown commit status "
-                    f"'{commit['status']}' for commit '{commit_sha}'"
-                )
-
-            return ReconciliationStatus.UNKNOWN
-
-        if merge_request_id is None:
-            logger.debug(f"No merge request id given, therefore checking commit status of '{commit_sha}'")
-            return await _get_commit_status(commit_sha, pipeline_timeout=pipeline_timeout)
-
-        logger.debug("Checking merge request status")
-        response = await self.client.get(
-            f"/projects/{quote_plus(incarnation_repository)}/merge_requests/{merge_request_id}"
-        )
-        response.raise_for_status()
-        merge_request: MergeRequest = response.json()
-
-        with bound(merge_request=merge_request):
-            if merge_request["state"] == "opened":
-                if merge_request["merge_status"] in {"cannot_be_merged", "cannot_be_merged_recheck"}:
-                    logger.debug(
-                        f"Reconciliation status: merge request state is open "
-                        f"and status is {merge_request['merge_status']}, returning FAILED"
-                    )
-                    return ReconciliationStatus.FAILED
-
-                if merge_request["head_pipeline"] is not None and merge_request["head_pipeline"]["status"] in {
-                    "failed",
-                    "canceled",
-                }:
-                    logger.debug(
-                        f"Reconciliation status: merge request state is open and pipeline status is "
-                        f"{merge_request['head_pipeline']['status']}, returning FAILED"
-                    )
-                    return ReconciliationStatus.FAILED
-
-                logger.debug("Reconciliation status: merge request state is open, returning PENDING")
-                return ReconciliationStatus.PENDING
-            elif merge_request["state"] == "merged":
-                if merge_request["merge_commit_sha"] is not None:
-                    logger.debug(
-                        f"Reconciliation status: merge request is merged at {merge_request['merge_commit_sha']}, "
-                        f"checking its commit status ..."
-                    )
-                    merge_commit_sha = merge_request["merge_commit_sha"]
-                    return await _get_commit_status(merge_commit_sha, pipeline_timeout=pipeline_timeout)
-                elif merge_request["sha"] is not None:
-                    logger.debug(
-                        f"Reconciliation status: merge request is merged without merge commit at {merge_request['sha']}, "
-                        f"checking its commit status ..."
-                    )
-                    sha = merge_request["sha"]
-                    return await _get_commit_status(sha, pipeline_timeout=pipeline_timeout)
-            elif merge_request["state"] == "closed":
-                logger.debug("Reconciliation status: merge request is closed, returning FAILED")
-                return ReconciliationStatus.FAILED
-
-            logger.error(
-                f"Incarnation '{incarnation_repository}' / '{target_directory}' has an unknown merge request status "
-                f"'{merge_request['state']}' for merge request '{merge_request_id}'"
-            )
-            return ReconciliationStatus.UNKNOWN
-
     async def get_commit_url(self, incarnation_repository: str, commit_sha: GitSha) -> str:
         return f"{self.web_address}/{incarnation_repository}/-/commit/{commit_sha}"
 
@@ -425,10 +311,3 @@ class GitLab(Hoster):
                 merge_request_id=merge_request_id,
             )
             return MergeRequestStatus.UNKNOWN
-
-    async def _has_gitlab_ci_configuration(self, incarnation_repository: str, ref: str) -> bool:
-        response = await self.client.head(
-            f"/projects/{quote_plus(incarnation_repository)}/repository/files/{quote_plus('.gitlab-ci.yml')}",
-            params={"ref": ref},
-        )
-        return response.status_code == HTTPStatus.OK

--- a/src/foxops/hosters/types.py
+++ b/src/foxops/hosters/types.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from enum import Enum
 from typing import AsyncContextManager, Protocol, TypedDict
 
@@ -59,16 +58,6 @@ class Hoster(Protocol):
         ...
 
     async def get_repository_metadata(self, project_identifier: str) -> RepositoryMetadata:
-        ...
-
-    async def get_reconciliation_status(
-        self,
-        incarnation_repository: str,
-        target_directory: str,
-        commit_sha: GitSha,
-        merge_request_id: str | None,
-        pipeline_timeout: timedelta | None = None,
-    ) -> ReconciliationStatus:
         ...
 
     async def get_commit_url(self, incarnation_repository: str, commit_sha: GitSha) -> str:

--- a/src/foxops/models/incarnation.py
+++ b/src/foxops/models/incarnation.py
@@ -1,7 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from foxops.engine.models import TemplateDataValue
-from foxops.hosters import ReconciliationStatus
 from foxops.hosters.types import MergeRequestStatus
 
 
@@ -34,7 +33,6 @@ class IncarnationBasic(BaseModel):
 
 
 class IncarnationWithDetails(IncarnationBasic):
-    status: ReconciliationStatus = Field(description="DEPRECATED. Use the 'merge_request_status' field instead.")
     merge_request_status: MergeRequestStatus | None
 
     template_repository: str | None

--- a/src/foxops/routers/incarnations.py
+++ b/src/foxops/routers/incarnations.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from fastapi import APIRouter, Depends, Response, status
 
 from foxops.database import DAL
@@ -261,16 +259,8 @@ async def delete_incarnation(
 async def get_incarnation_with_details(incarnation: Incarnation, hoster: Hoster) -> IncarnationWithDetails:
     incarnation_basic = await get_incarnation_basic(incarnation, hoster)
 
-    reconciliation_status = await hoster.get_reconciliation_status(
-        incarnation.incarnation_repository,
-        incarnation.target_directory,
-        incarnation.commit_sha,
-        incarnation.merge_request_id,
-        pipeline_timeout=timedelta(minutes=1),
-    )
     response = IncarnationWithDetails(
         **incarnation_basic.dict(),
-        status=reconciliation_status,
     )
 
     if incarnation.merge_request_id is not None:

--- a/tests/e2e/hosters/test_gitlab.py
+++ b/tests/e2e/hosters/test_gitlab.py
@@ -1,7 +1,6 @@
 import base64
 import uuid
 from collections import namedtuple
-from datetime import timedelta
 
 import pytest
 from httpx import AsyncClient, HTTPStatusError
@@ -10,7 +9,7 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
-from foxops.hosters import Hoster, ReconciliationStatus
+from foxops.hosters import Hoster
 from foxops.hosters.gitlab import GitLab
 from foxops.hosters.types import MergeRequestStatus
 
@@ -78,37 +77,6 @@ build:
 @pytest.fixture(name="test_gitlab_hoster")
 async def create_test_gitlab_hoster(gitlab_test_address: str, gitlab_test_user_token: str) -> Hoster:
     return GitLab(gitlab_test_address, gitlab_test_user_token)
-
-
-async def should_return_success_reconciliation_status_for_default_branch_commit_without_pipeline(
-    test_gitlab_hoster: Hoster, test_repository: RepositoryTestData
-):
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_main,
-        merge_request_id=None,
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.SUCCESS
-
-
-async def should_return_pending_reconciliation_status_for_default_branch_commit_with_pending_pipeline(
-    test_gitlab_hoster: Hoster, test_repository: RepositoryTestData
-):
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_branch_with_pipeline,
-        merge_request_id=None,
-        pipeline_timeout=timedelta(seconds=10),
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.PENDING
 
 
 async def should_return_open_merge_request_status_for_open_merge_request(
@@ -206,149 +174,3 @@ async def should_return_closed_merge_request_status_for_closed_merge_request(
 
     # THEN
     assert status == MergeRequestStatus.CLOSED
-
-
-async def should_return_pending_reconciliation_status_for_open_merge_request(
-    test_gitlab_hoster: Hoster, gitlab_test_client: AsyncClient, test_repository: RepositoryTestData
-):
-    # GIVEN
-    response = await gitlab_test_client.post(
-        f"/projects/{test_repository.project['id']}/merge_requests",
-        json={
-            "source_branch": "without-pipeline",
-            "target_branch": test_repository.project["default_branch"],
-            "title": "Some merge request",
-        },
-    )
-    response.raise_for_status()
-    merge_request = response.json()
-
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_branch_without_pipeline,
-        merge_request_id=merge_request["iid"],
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.PENDING
-
-
-async def should_return_success_reconciliation_status_for_merged_merge_request_without_pipeline_in_target_branch(
-    test_gitlab_hoster: Hoster, gitlab_test_client: AsyncClient, test_repository: RepositoryTestData
-):
-    # GIVEN
-    response = await gitlab_test_client.post(
-        f"/projects/{test_repository.project['id']}/merge_requests",
-        json={
-            "source_branch": "without-pipeline",
-            "target_branch": test_repository.project["default_branch"],
-            "title": "Some merge request",
-        },
-    )
-    response.raise_for_status()
-    merge_request = response.json()
-
-    @retry(
-        retry=retry_if_exception_type(HTTPStatusError),
-        stop=stop_after_delay(10),
-        wait=wait_fixed(1),
-    )
-    async def __merge():
-        (
-            await gitlab_test_client.put(
-                f"/projects/{test_repository.project['id']}/merge_requests/{merge_request['iid']}/merge",
-            )
-        ).raise_for_status()
-
-    await __merge()
-
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_branch_without_pipeline,
-        merge_request_id=merge_request["iid"],
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.SUCCESS
-
-
-async def should_return_success_reconciliation_status_for_merged_merge_request_without_merge_commit_and_without_pipeline_in_target_branch(  # noqa: B950
-    test_gitlab_hoster: Hoster, gitlab_test_client: AsyncClient, test_repository: RepositoryTestData
-):
-    # GIVEN
-    (
-        await gitlab_test_client.put(f"/projects/{test_repository.project['id']}", json={"merge_method": "ff"})
-    ).raise_for_status()
-
-    response = await gitlab_test_client.post(
-        f"/projects/{test_repository.project['id']}/merge_requests",
-        json={
-            "source_branch": "without-pipeline",
-            "target_branch": test_repository.project["default_branch"],
-            "title": "Some merge request",
-        },
-    )
-    response.raise_for_status()
-    merge_request = response.json()
-
-    @retry(
-        retry=retry_if_exception_type(HTTPStatusError),
-        stop=stop_after_delay(10),
-        wait=wait_fixed(1),
-    )
-    async def __merge():
-        (
-            await gitlab_test_client.put(
-                f"/projects/{test_repository.project['id']}/merge_requests/{merge_request['iid']}/merge",
-            )
-        ).raise_for_status()
-
-    await __merge()
-
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_branch_without_pipeline,
-        merge_request_id=merge_request["iid"],
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.SUCCESS
-
-
-async def should_return_failed_reconciliation_status_for_closed_merge_request(
-    test_gitlab_hoster: Hoster, gitlab_test_client: AsyncClient, test_repository: RepositoryTestData
-):
-    # GIVEN
-    response = await gitlab_test_client.post(
-        f"/projects/{test_repository.project['id']}/merge_requests",
-        json={
-            "source_branch": "without-pipeline",
-            "target_branch": test_repository.project["default_branch"],
-            "title": "Some merge request",
-        },
-    )
-    response.raise_for_status()
-    merge_request = response.json()
-    (
-        await gitlab_test_client.put(
-            f"/projects/{test_repository.project['id']}/merge_requests/{merge_request['iid']}",
-            json={"state_event": "close"},
-        )
-    ).raise_for_status()
-
-    # WHEN
-    status = await test_gitlab_hoster.get_reconciliation_status(
-        incarnation_repository=test_repository.project["path_with_namespace"],
-        target_directory=".",
-        commit_sha=test_repository.commit_sha_branch_without_pipeline,
-        merge_request_id=merge_request["iid"],
-    )
-
-    # THEN
-    assert status == ReconciliationStatus.FAILED

--- a/tests/e2e/test_incarnations_api.py
+++ b/tests/e2e/test_incarnations_api.py
@@ -44,7 +44,6 @@ async def should_initialize_incarnation_in_root_of_empty_repository_when_creatin
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "success"
     assert incarnation["template_repository"] == template_repository
     assert incarnation["template_repository_version"] == template_repository_version
     assert incarnation["template_data"] == template_data
@@ -101,7 +100,6 @@ async def should_initialize_incarnation_in_root_of_repository_with_fvars_file_wh
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
 
@@ -149,7 +147,6 @@ async def should_initialize_incarnation_in_root_of_nonempty_incarnation_in_a_mer
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "pending"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     assert incarnation["merge_request_status"] == "open"
@@ -203,7 +200,6 @@ async def should_initialize_incarnation_in_root_of_nonempty_incarnation_in_defau
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     assert incarnation["merge_request_status"] == "merged"
@@ -263,7 +259,6 @@ async def should_initialize_incarnation_in_root_of_nonempty_repository_with_fvar
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "pending"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     merge_request_branch_name = await assert_initialization_merge_request_exists(
@@ -327,7 +322,6 @@ async def should_initialize_incarnation_in_subdir_of_empty_repository_when_creat
     # THEN
     assert incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert incarnation["target_directory"] == "subdir"
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     assert incarnation["merge_request_status"] is None
@@ -378,14 +372,12 @@ async def should_initialize_incarnations_in_subdirs_of_empty_repository_when_cre
     assert subdir1_incarnation["id"] == 1
     assert subdir1_incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert subdir1_incarnation["target_directory"] == "subdir1"
-    assert subdir1_incarnation["status"] == "success"
     assert subdir1_incarnation["commit_url"] == mocker.ANY
     assert subdir1_incarnation["merge_request_url"] == mocker.ANY
 
     assert subdir2_incarnation["id"] == 2
     assert subdir2_incarnation["incarnation_repository"] == empty_incarnation_gitlab_repository
     assert subdir2_incarnation["target_directory"] == "subdir2"
-    assert subdir2_incarnation["status"] == "success"
     assert subdir2_incarnation["commit_url"] == mocker.ANY
     assert subdir2_incarnation["merge_request_url"] == mocker.ANY
 
@@ -427,7 +419,6 @@ async def should_create_merge_request_when_file_changed_during_update(
     # THEN
     assert incarnation["incarnation_repository"] == incarnation_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "pending"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
 
@@ -476,7 +467,6 @@ async def should_create_merge_request_when_file_changed_with_fvars_during_update
     # THEN
     assert incarnation["incarnation_repository"] == incarnation_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "pending"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
 
@@ -527,7 +517,6 @@ async def should_present_conflict_in_merge_request_when_updating(
     # THEN
     assert incarnation["incarnation_repository"] == incarnation_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "pending"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     assert incarnation["merge_request_status"] == "open"
@@ -563,7 +552,6 @@ async def should_automerge_merge_request_when_flag_is_true(
     # THEN
     assert incarnation["incarnation_repository"] == incarnation_repository
     assert incarnation["target_directory"] == "."
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == mocker.ANY
     assert incarnation["merge_request_url"] == mocker.ANY
     assert incarnation["merge_request_status"] == "merged"

--- a/tests/routers/test_incarnations.py
+++ b/tests/routers/test_incarnations.py
@@ -69,7 +69,6 @@ async def test_api_create_incarnation_adds_new_incarnation_to_inventory(
         template_repository_version_hash="hash",
         template_data={"foo": "bar"},
     )
-    hoster_mock.get_reconciliation_status.return_value = "success"
     hoster_mock.get_commit_url.return_value = "some-commit-url"
     hoster_mock.get_merge_request_url.return_value = "some-merge-request-url"
     hoster_mock.get_merge_request_status.return_value = MergeRequestStatus.OPEN
@@ -100,7 +99,6 @@ async def test_api_create_incarnation_adds_new_incarnation_to_inventory(
         "merge_request_id": "merge_request_id",
         "merge_request_url": "some-merge-request-url",
         "merge_request_status": "open",
-        "status": "success",
         "template_repository": "test",
         "template_repository_version": "version",
         "template_repository_version_hash": "hash",
@@ -165,7 +163,6 @@ async def test_api_create_incarnation_already_exists_allowing_import_without_a_m
     )
 
     hoster_mock = mocker.AsyncMock()
-    hoster_mock.get_reconciliation_status.return_value = "success"
     hoster_mock.get_commit_url.return_value = "some-commit-url"
     hoster_mock.get_merge_request_url.return_value = "some-merge-request-url"
     hoster_mock.get_merge_request_status.return_value = MergeRequestStatus.MERGED
@@ -193,7 +190,6 @@ async def test_api_create_incarnation_already_exists_allowing_import_without_a_m
     assert incarnation["id"] == 1
     assert incarnation["incarnation_repository"] == "test"
     assert incarnation["target_directory"] == "test"
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == "some-commit-url"
     assert incarnation["merge_request_url"] == "some-merge-request-url"
 
@@ -218,7 +214,6 @@ async def test_api_create_incarnation_already_exists_allowing_import_with_a_mism
     )
 
     hoster_mock = mocker.AsyncMock()
-    hoster_mock.get_reconciliation_status.return_value = "success"
     hoster_mock.get_commit_url.return_value = "some-commit-url"
     hoster_mock.get_merge_request_url.return_value = "some-merge-request-url"
     hoster_mock.get_merge_request_status.return_value = MergeRequestStatus.MERGED
@@ -246,7 +241,6 @@ async def test_api_create_incarnation_already_exists_allowing_import_with_a_mism
     assert incarnation["id"] == 1
     assert incarnation["incarnation_repository"] == "test"
     assert incarnation["target_directory"] == "test"
-    assert incarnation["status"] == "success"
     assert incarnation["commit_url"] == "some-commit-url"
     assert incarnation["merge_request_url"] == "some-merge-request-url"
 


### PR DESCRIPTION
this field was giving misleading information and in some cases could significantly slow down foxops (as it was waiting for a timeout of the pipeline to appear)