### PR TITLE
add `_fengine` variable to the template data during rendering

### DIFF
--- a/src/foxops/engine/initialization.py
+++ b/src/foxops/engine/initialization.py
@@ -78,10 +78,12 @@ async def _initialize_incarnation(
     # add meta-information to the template data.
     # ... we don't want to include that in the "template_data" section of the `.fengine.yaml` file
     template_data_with_defaults_and_metadata = copy.deepcopy(template_data_with_defaults)
-    template_data_with_defaults_and_metadata.update({
-        "_fengine_template_repository": template_repository,
-        "_fengine_template_repository_version": template_repository_version,
-    })
+    template_data_with_defaults_and_metadata.update(
+        {
+            "_fengine_template_repository": template_repository,
+            "_fengine_template_repository_version": template_repository_version,
+        }
+    )
 
     await render_template(
         template_root_dir / "template",

--- a/src/foxops/engine/initialization.py
+++ b/src/foxops/engine/initialization.py
@@ -1,4 +1,3 @@
-import copy
 from pathlib import Path
 
 from foxops.engine.fvars import merge_template_data_with_fvars
@@ -90,10 +89,8 @@ async def _initialize_incarnation(
     logger.debug(f"save incarnation state to {incarnation_config_path} after template initialization")
 
     # add meta-information to the template data
-    template_data_with_defaults["_fengine"] = {
-        "template_repository": template_repository,
-        "template_repository_version": template_repository_version,
-    }
+    template_data_with_defaults["_fengine_template_repository"] = template_repository
+    template_data_with_defaults["_fengine_template_repository_version"] = template_repository_version
 
     await render_template(
         template_root_dir / "template",

--- a/src/foxops/engine/initialization.py
+++ b/src/foxops/engine/initialization.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 from foxops.engine.fvars import merge_template_data_with_fvars
@@ -74,8 +75,21 @@ async def _initialize_incarnation(
         template_config=template_config,
     )
 
-    # save the incarnation state. We do that before adding the metadata to the template data
-    # so that the metadata is not included in the .fengine.yaml file
+    # add meta-information to the template data.
+    # ... we don't want to include that in the "template_data" section of the `.fengine.yaml` file
+    template_data_with_defaults_and_metadata = copy.deepcopy(template_data_with_defaults)
+    template_data_with_defaults_and_metadata.update({
+        "_fengine_template_repository": template_repository,
+        "_fengine_template_repository_version": template_repository_version,
+    })
+
+    await render_template(
+        template_root_dir / "template",
+        incarnation_root_dir,
+        template_data_with_defaults_and_metadata,
+        rendering_filename_exclude_patterns=template_config.rendering.excluded_files,
+    )
+
     template_repository_version_hash = await GitRepository(template_root_dir).head()
     incarnation_state = IncarnationState(
         template_repository=template_repository,
@@ -87,15 +101,4 @@ async def _initialize_incarnation(
     incarnation_config_path = Path(incarnation_root_dir, ".fengine.yaml")
     save_incarnation_state(incarnation_config_path, incarnation_state)
     logger.debug(f"save incarnation state to {incarnation_config_path} after template initialization")
-
-    # add meta-information to the template data
-    template_data_with_defaults["_fengine_template_repository"] = template_repository
-    template_data_with_defaults["_fengine_template_repository_version"] = template_repository_version
-
-    await render_template(
-        template_root_dir / "template",
-        incarnation_root_dir,
-        template_data_with_defaults,
-        rendering_filename_exclude_patterns=template_config.rendering.excluded_files,
-    )
     return incarnation_state

--- a/tests/engine/test_initialization.py
+++ b/tests/engine/test_initialization.py
@@ -63,6 +63,31 @@ template_repository_version_hash: {repository_head}
     )
 
 
+async def test_initialize_template_at_root_of_incarnation_repository_using_fengine_metadata(tmp_path: Path):
+    # GIVEN
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    (template_dir / "template_repository").write_text("{{ _fengine.template_repository }}")
+    (template_dir / "template_repository_version").write_text("{{ _fengine.template_repository_version }}")
+    await init_repository(tmp_path)
+
+    incarnation_dir = tmp_path / "incarnation"
+    incarnation_dir.mkdir()
+
+    # WHEN
+    await initialize_incarnation(
+        template_root_dir=tmp_path,
+        template_repository="any-repository-url",
+        template_repository_version="any-version",
+        template_data={"author": "John Doe", "three": "3"},
+        incarnation_root_dir=incarnation_dir,
+    )
+
+    # THEN
+    assert (incarnation_dir / "template_repository").read_text() == "any-repository-url"
+    assert (incarnation_dir / "template_repository_version").read_text() == "any-version"
+
+
 async def test_initialize_template_at_root_of_incarnation_repository_with_existing_file(
     tmp_path: Path,
 ):

--- a/tests/engine/test_initialization.py
+++ b/tests/engine/test_initialization.py
@@ -67,8 +67,8 @@ async def test_initialize_template_at_root_of_incarnation_repository_using_fengi
     # GIVEN
     template_dir = tmp_path / "template"
     template_dir.mkdir()
-    (template_dir / "template_repository").write_text("{{ _fengine.template_repository }}")
-    (template_dir / "template_repository_version").write_text("{{ _fengine.template_repository_version }}")
+    (template_dir / "template_repository").write_text("{{ _fengine_template_repository }}")
+    (template_dir / "template_repository_version").write_text("{{ _fengine_template_repository_version }}")
     await init_repository(tmp_path)
 
     incarnation_dir = tmp_path / "incarnation"


### PR DESCRIPTION
It includes additional information about the template that is currently being rendered (like the template version)

Usage:
* `{{ _fengine_template_repository }}`
* `{{ _fengine_template_repository_version }}`