### PR TITLE
unify the logic how the provided template data is stored

### DIFF
--- a/src/foxops/engine/initialization.py
+++ b/src/foxops/engine/initialization.py
@@ -62,7 +62,7 @@ async def initialize_incarnation(
         template_repository=template_repository,
         template_repository_version=template_repository_version,
         template_repository_version_hash=template_repository_version_hash,
-        template_data=template_data_model.model_dump(exclude_defaults=True),
+        template_data=template_data,
         template_data_full=full_template_data,
     )
     incarnation_state.save(incarnation_root_dir / ".fengine.yaml")

--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -188,7 +188,7 @@ class ChangeService:
                 commit_sha=commit_sha,
                 requested_version_hash=incarnation_state.template_repository_version_hash,
                 requested_version=template_repository_version,
-                requested_data=json.dumps(template_data),
+                requested_data=json.dumps(incarnation_state.template_data),
                 template_data_full=json.dumps(incarnation_state.template_data_full),
             )
 

--- a/tests/engine/test_initialization.py
+++ b/tests/engine/test_initialization.py
@@ -272,5 +272,5 @@ variables:
 
     # THEN
     assert incarnation_state is not None
-    assert "additional_variable_1" not in incarnation_state.template_data
-    assert "additional_variable_2" not in incarnation_state.template_data
+    assert "additional_variable_1" in incarnation_state.template_data
+    assert "additional_variable_2" in incarnation_state.template_data


### PR DESCRIPTION
to prevent inconsistencies between creation/updates of an incarnation, the .fengine.yaml template_data is now configured to always contain all the data provided by the user. No longer limiting it to values that are provided for valid variables or that are different from the defaults