### PR TITLE
[nal-756]fixing ReadTheDocs build issue

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ build:
       - asdf global poetry latest
       - poetry config virtualenvs.create false
     post_install:
+      - poetry self add poetry-plugin-export
       - poetry export --with=dev -o requirements.txt
       - pip install -r requirements.txt
 


### PR DESCRIPTION
Fixing the issue when ReadTheDocs builds for the foxops documentation have been failing since a recent Poetry upgrade, due to the poetry export command not being available in the new version.