### PR TITLE
add support for .fengine-reset-ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ typecheck:
 	poetry run dmypy run -- src tests
 
 pre-commit: fmt lint typecheck
+
+test:
+	poetry run pytest tests

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -5,4 +5,5 @@
 
 write-template-from-scratch
 backwards-compatible-template-changes
+reset-incarnation
 ```

--- a/docs/source/tutorials/reset-incarnation.md
+++ b/docs/source/tutorials/reset-incarnation.md
@@ -8,7 +8,54 @@ to the incarnation, but they can be overridden. For the data, partial overrides 
 ## Ignore some files from reset
 Sometimes, you want to keep some files in the incarnation that were created or modified after the initial
 creation of the incarnation. For example, you might have a `pipeline.yaml` which is created by different process.
-To achieve this, you can create a file called `.foxops-reset-ignore` in the root of your template. It would propagate it
+To achieve this, you can create a file called `.fengine-reset-ignore` in the root of your template. It would propagate it
 to the root of your incarnation repository.
 
 This file should contain a list of file paths (one per line) that should be ignored during the reset process.
+
+### Examples
+
+#### Ignoring top-level files and directories
+
+To ignore files or directories at the root level:
+
+```
+pipeline.yaml
+config/
+.env
+```
+
+This will preserve `pipeline.yaml`, the entire `config/` directory, and `.env` during reset.
+
+#### Ignoring specific nested files
+
+You can also ignore specific files within directories while still allowing other files in the same directory to be reset:
+
+```
+example/file1
+config/secrets.yaml
+src/generated/api.py
+```
+
+With this configuration:
+- `example/file1` is preserved, but `example/file2` would be deleted
+- `config/secrets.yaml` is preserved, but other files in `config/` would be deleted
+- `src/generated/api.py` is preserved, but other files in `src/generated/` would be deleted
+
+#### Combining top-level and nested exclusions
+
+You can mix both styles:
+
+```
+.env
+config/
+src/custom/special_file.py
+docs/generated/api-reference.md
+```
+
+This will:
+- Preserve the entire `config/` directory
+- Preserve `.env` at the root
+- Preserve only `special_file.py` in `src/custom/` (other files in that directory will be deleted)
+- Preserve only `api-reference.md` in `docs/generated/` (other files will be deleted)
+

--- a/docs/source/tutorials/reset-incarnation.md
+++ b/docs/source/tutorials/reset-incarnation.md
@@ -8,8 +8,12 @@ to the incarnation, but they can be overridden. For the data, partial overrides 
 ## Ignore some files from reset
 Sometimes, you want to keep some files in the incarnation that were created or modified after the initial
 creation of the incarnation. For example, you might have a `pipeline.yaml` which is created by different process.
-To achieve this, you can create a file called `.fengine-reset-ignore` in the root of your template. It would propagate it
-to the root of your incarnation repository.
+To achieve this, you can create a file called `.fengine-reset-ignore` in the root of your incarnation repository (that
+is about to be reset) and add the path to the file you want to preserve.
+
+Additionally, if you need to ignore identical files across all incarnations, you can add .fengine-reset-ignore to your
+template. This file will propagate to all incarnations through foxops' usual synchronization mechanisms. That's actually
+the expected usecase otherwise the `.fengine-reset-ignore` file would be also deleted/overwritten during reset.
 
 This file should contain a list of file paths (one per line) that should be ignored during the reset process.
 

--- a/docs/source/tutorials/reset-incarnation.md
+++ b/docs/source/tutorials/reset-incarnation.md
@@ -1,0 +1,14 @@
+# Reset incarnation
+There is an option to reset an incarnation by removing all customizations that were done to it and bring it back to
+a pristine state as if it was just created freshly from the template.
+
+By default, the target version and data is taken from the last change that was successfully applied
+to the incarnation, but they can be overridden. For the data, partial overrides are also allowed.
+
+## Ignore some files from reset
+Sometimes, you want to keep some files in the incarnation that were created or modified after the initial
+creation of the incarnation. For example, you might have a `pipeline.yaml` which is created by different process.
+To achieve this, you can create a file called `.foxops-reset-ignore` in the root of your template. It would propagate it
+to the root of your incarnation repository.
+
+This file should contain a list of file paths (one per line) that should be ignored during the reset process.

--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -793,29 +793,15 @@ def _is_ignored(path: Path, directory: Path, ignore_list: frozenset[Path]) -> bo
 def delete_all_files_in_local_git_repository(directory: Path) -> None:
     ignore_list = _load_fengine_reset_ignore(directory)
 
-    # Walk bottom-up so we process children before parents
-    for root, dirs, files in directory.walk(top_down=False):
-        # Skip .git directory and its contents entirely
-        if ".git" in root.parts:
-            continue
+    for root, dirs, files in directory.walk(top_down=True):
+        if ".git" in dirs:
+            dirs.remove(".git")
 
         # Delete files that aren't ignored
         for name in files:
             path = root / name
             if not _is_ignored(path, directory, ignore_list):
                 path.unlink()
-
-        # Delete directories that aren't ignored and are now empty
-        for name in dirs:
-            if name == ".git" and root == directory:
-                continue
-
-            path = root / name
-            if not _is_ignored(path, directory, ignore_list):
-                try:
-                    path.rmdir()
-                except OSError:
-                    pass
 
 
 def generate_foxops_branch_name(prefix: str, target_directory: str, template_repository_version: str) -> str:

--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -772,9 +772,28 @@ def _construct_merge_request_conflict_description(
     return "\n\n".join(description_paragraphs)
 
 
+def _load_fengine_reset_ignore(directory: Path) -> frozenset[str]:
+    """Load the content of .fengine-reset-ignore file from the given directory.
+    The file contains a list of file/folder names (one per line) that should be
+    skipped during file deletion in delete_all_files_in_local_git_repository.
+    """
+    ignore_file = directory / ".fengine-reset-ignore"
+    if not ignore_file.exists():
+        return frozenset()
+
+    content = ignore_file.read_text()
+    ignore_list = frozenset(line.strip() for line in content.splitlines() if line.strip())
+    return ignore_list
+
+
 def delete_all_files_in_local_git_repository(directory: Path) -> None:
+    ignore_list = _load_fengine_reset_ignore(directory)
+
     for file in directory.glob("*"):
         if file.name == ".git":
+            continue
+
+        if file.name in ignore_list:
             continue
 
         if file.is_dir():

--- a/tests/services/test_change.py
+++ b/tests/services/test_change.py
@@ -780,3 +780,50 @@ def test_delete_all_files_in_local_git_repository_handles_whitespace_in_fengine_
     assert (tmp_path / "keep_me.txt").exists()
     assert (tmp_path / "keep_folder").exists()
     assert not (tmp_path / "delete_me.txt").exists()
+
+
+def test_delete_all_files_in_local_git_repository_respects_nested_path_exclusions(tmp_path):
+    # GIVEN
+    (tmp_path / ".fengine-reset-ignore").write_text("example/file1")
+    (tmp_path / "example").mkdir()
+    (tmp_path / "example" / "file1").write_text("I should remain")
+    (tmp_path / "example" / "file2").write_text("I should be deleted")
+    (tmp_path / "example" / "nested").mkdir()
+    (tmp_path / "example" / "nested" / "file3").write_text("I should be deleted")
+    (tmp_path / "other_folder").mkdir()
+    (tmp_path / "other_folder" / "file4").write_text("I should be deleted")
+
+    # WHEN
+    delete_all_files_in_local_git_repository(tmp_path)
+
+    # THEN
+    assert (tmp_path / "example").exists()
+    assert (tmp_path / "example" / "file1").exists()
+    assert not (tmp_path / "example" / "file2").exists()
+    assert not (tmp_path / "example" / "nested").exists()
+    assert not (tmp_path / "other_folder").exists()
+
+
+def test_delete_all_files_in_local_git_repository_respects_multiple_nested_path_exclusions(tmp_path):
+    # GIVEN
+    (tmp_path / ".fengine-reset-ignore").write_text("example/file1\nexample/nested/deep_file")
+    (tmp_path / "example").mkdir()
+    (tmp_path / "example" / "file1").write_text("I should remain")
+    (tmp_path / "example" / "file2").write_text("I should be deleted")
+    (tmp_path / "example" / "nested").mkdir()
+    (tmp_path / "example" / "nested" / "deep_file").write_text("I should remain")
+    (tmp_path / "example" / "nested" / "other_file").write_text("I should be deleted")
+    (tmp_path / "other_folder").mkdir()
+    (tmp_path / "other_folder" / "file4").write_text("I should be deleted")
+
+    # WHEN
+    delete_all_files_in_local_git_repository(tmp_path)
+
+    # THEN
+    assert (tmp_path / "example").exists()
+    assert (tmp_path / "example" / "file1").exists()
+    assert not (tmp_path / "example" / "file2").exists()
+    assert (tmp_path / "example" / "nested").exists()
+    assert (tmp_path / "example" / "nested" / "deep_file").exists()
+    assert not (tmp_path / "example" / "nested" / "other_file").exists()
+    assert not (tmp_path / "other_folder").exists()

--- a/tests/services/test_change.py
+++ b/tests/services/test_change.py
@@ -680,6 +680,7 @@ async def test_reset_incarnation_fails_when_incarnation_does_not_exist(change_se
 def test_delete_all_files_in_local_git_repository_removes_hidden_directories_and_files(tmp_path):
     # GIVEN
     (tmp_path / ".dummy_folder").mkdir()
+    (tmp_path / ".dummy_folder" / "file.txt").write_text("content")
     (tmp_path / "dummy_folder2").mkdir()
     (tmp_path / "dummy_folder2" / ".myfile").write_text("Hello, world!")
     (tmp_path / ".config").write_text("Hello, world!")
@@ -688,16 +689,15 @@ def test_delete_all_files_in_local_git_repository_removes_hidden_directories_and
     delete_all_files_in_local_git_repository(tmp_path)
 
     # THEN
-    assert not (tmp_path / ".dummy_folder").exists()
+    assert not (tmp_path / ".dummy_folder" / "file.txt").exists()
     assert not (tmp_path / "dummy_folder2" / ".myfile").exists()
     assert not (tmp_path / ".config").exists()
 
 
-def test_delete_all_files_in_local_git_repository_does_not_delete_git_directory_in_root_folder(tmp_path):
+def test_delete_all_files_in_local_git_repository_does_not_delete_git_directory(tmp_path):
     # GIVEN
     (tmp_path / ".git").mkdir()
-    (tmp_path / "subfolder").mkdir()
-    (tmp_path / "subfolder" / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("git config")
     (tmp_path / "README.md").write_text("Hello, world!")
 
     # WHEN
@@ -705,7 +705,7 @@ def test_delete_all_files_in_local_git_repository_does_not_delete_git_directory_
 
     # THEN
     assert (tmp_path / ".git").exists()
-    assert not (tmp_path / "subfolder" / ".git").exists()
+    assert (tmp_path / ".git" / "config").exists()
     assert not (tmp_path / "README.md").exists()
 
 
@@ -870,7 +870,7 @@ def test_delete_all_files_in_local_git_repository_respects_fengine_reset_ignore(
 
     # THEN - deleted files
     assert not (tmp_path / "delete_me.txt").exists()
-    assert not (tmp_path / "delete_folder").exists()
+    assert not (tmp_path / "delete_folder" / "some_file.txt").exists()
     assert not (tmp_path / "example" / "file_to_delete.txt").exists()
     assert not (tmp_path / "example" / "nested" / "other_file.txt").exists()
     assert not (tmp_path / ".fengine-reset-ignore").exists()


### PR DESCRIPTION
Add support for .fengine-reset-ignore to preserve specified files and directories during reset endpoint invocation.
