### PR TITLE
fix: return UNKNOWN status instead of raising when change is incomplete

### DIFF
--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -25,7 +25,7 @@ from foxops.engine.patching.git_diff_patch import PatchResult
 from foxops.errors import RetryableError
 from foxops.external.git import GitError, GitRepository
 from foxops.hosters import Hoster
-from foxops.hosters.types import MergeRequestStatus
+from foxops.hosters.types import MergeRequestStatus, ReconciliationStatus
 from foxops.models import IncarnationWithDetails
 from foxops.models.change import Change, ChangeWithMergeRequest
 from foxops.utils import get_logger
@@ -545,20 +545,45 @@ class ChangeService:
         merge_request_status: MergeRequestStatus | None = None
 
         change: Change | ChangeWithMergeRequest
-        if change_type == ChangeType.MERGE_REQUEST:
-            change = await self.get_change_with_merge_request(change_id)
+        try:
+            if change_type == ChangeType.MERGE_REQUEST:
+                change = await self.get_change_with_merge_request(change_id)
 
-            merge_request_id = change.merge_request_id
-            merge_request_status = await self._hoster.get_merge_request_status(
-                incarnation.incarnation_repository, merge_request_id
+                merge_request_id = change.merge_request_id
+                merge_request_status = await self._hoster.get_merge_request_status(
+                    incarnation.incarnation_repository, merge_request_id
+                )
+                merge_request_url = await self._hoster.get_merge_request_url(
+                    incarnation.incarnation_repository, merge_request_id
+                )
+            elif change_type == ChangeType.DIRECT:
+                change = await self.get_change(change_id)
+            else:
+                raise ValueError(f"Unknown change type {change_type}")
+        except IncompleteChange:
+            # The latest change has not been fully committed/pushed yet. Return what is known
+            # from the database so that the incarnation remains readable and deletable.
+            # Use the fix endpoint to repair the change before attempting further updates.
+            change_in_db = await self._change_repository.get_change(change_id)
+            return IncarnationWithDetails(
+                id=incarnation.id,
+                incarnation_repository=incarnation.incarnation_repository,
+                target_directory=incarnation.target_directory,
+                commit_sha=change_in_db.commit_sha,
+                commit_url=await self._hoster.get_commit_url(
+                    incarnation.incarnation_repository, change_in_db.commit_sha
+                ),
+                merge_request_id=change_in_db.merge_request_id,
+                merge_request_url=None,
+                merge_request_status=None,
+                status=ReconciliationStatus.UNKNOWN,
+                revision=change_in_db.revision,
+                template_repository=incarnation.template_repository,
+                template_repository_version=change_in_db.requested_version,
+                template_repository_version_hash=change_in_db.requested_version_hash,
+                template_data=json.loads(change_in_db.requested_data),
+                template_data_full=json.loads(change_in_db.template_data_full),
             )
-            merge_request_url = await self._hoster.get_merge_request_url(
-                incarnation.incarnation_repository, merge_request_id
-            )
-        elif change_type == ChangeType.DIRECT:
-            change = await self.get_change(change_id)
-        else:
-            raise ValueError(f"Unknown change type {change_type}")
 
         status = await self._hoster.get_reconciliation_status(
             incarnation_repository=incarnation.incarnation_repository,

--- a/tests/services/test_change.py
+++ b/tests/services/test_change.py
@@ -16,7 +16,7 @@ from foxops.engine.models.template_config import (
 )
 from foxops.external.git import git_exec
 from foxops.hosters.local import LocalHoster
-from foxops.hosters.types import MergeRequestStatus
+from foxops.hosters.types import MergeRequestStatus, ReconciliationStatus
 from foxops.models import Incarnation
 from foxops.models.change import Change, ChangeWithMergeRequest
 from foxops.services.change import (
@@ -481,6 +481,25 @@ async def test_list_changes(
 
     assert isinstance(changes[1], Change)
     assert changes[1].revision == 1
+
+
+async def test_get_incarnation_with_details_returns_unknown_status_when_change_is_incomplete(
+    change_service: ChangeService, initialized_incarnation: Incarnation
+):
+    # GIVEN a change whose commit was never pushed (commit_pushed=False)
+    change = await change_service.create_change_direct(
+        initialized_incarnation.id, requested_version="v1.1.0", requested_data={}
+    )
+    await change_service._change_repository.update_commit_pushed(change.id, False)
+
+    # WHEN
+    details = await change_service.get_incarnation_with_details(initialized_incarnation.id)
+
+    # THEN the incarnation is still readable with UNKNOWN reconciliation status
+    assert details.id == initialized_incarnation.id
+    assert details.status == ReconciliationStatus.UNKNOWN
+    assert details.revision == change.revision
+    assert details.merge_request_status is None
 
 
 async def test_update_incomplete_change_recovers_from_unpushed_direct_change(


### PR DESCRIPTION
## Summary

- `GET /incarnations/{id}` was propagating `IncompleteChange` as an unhandled 500 when the latest change had `commit_pushed=False`
- `get_incarnation_with_details` now catches `IncompleteChange`, reads the raw DB row, and returns a valid `IncarnationWithDetails` with `status=UNKNOWN`
- The fix endpoint (`POST /incarnations/{id}/changes/{revision}/fix`) remains the correct path to repair the change

## Impact

The Terraform provider calls `Read` before `Delete` as part of its refresh cycle. A 500 from `GET /incarnations/{id}` caused `Read` to fail with a diagnostic error, preventing `Delete` from running — making the incarnation impossible to remove via `terraform destroy`. The UI had the same problem: the delete button is only rendered on a successful GET.

## Test plan

- [ ] New test `test_get_incarnation_with_details_returns_unknown_status_when_change_is_incomplete` verifies the service returns `ReconciliationStatus.UNKNOWN` rather than raising when `commit_pushed=False`
- [ ] Full service test suite (41 tests) passes

Closes #569 (Internal ticket: NAFM-1349)