### PR TITLE
fix: render git subprocess errors with decoded, labelled output

### DIFF
--- a/src/foxops/utils.py
+++ b/src/foxops/utils.py
@@ -11,8 +11,19 @@ class CalledProcessError(subprocess.CalledProcessError, FoxopsError):
     """Error raised when copier fails."""
 
     def __str__(self):
-        """Extend so that the string prints stdout and stderr by default."""
-        return f"{super().__str__()} with stdout '{self.stdout}' and stderr '{self.stderr}'"
+        def decode(data):
+            if isinstance(data, bytes):
+                return data.decode(errors="replace")
+            return data or ""
+
+        parts = [f"Command {self.cmd!r} returned non-zero exit status {self.returncode}."]
+        stdout = decode(self.stdout).strip()
+        stderr = decode(self.stderr).strip()
+        if stdout:
+            parts.append(f"stdout:\n{stdout}")
+        if stderr:
+            parts.append(f"stderr:\n{stderr}")
+        return "\n".join(parts)
 
 
 async def check_call(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,13 +3,14 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from foxops.utils import CalledProcessError as FoxopsCalledProcessError
 from foxops.utils import check_call
 
 
 async def test_check_call_should_raise_exception_on_non_zero_exit_code():
     # GIVEN
     program = "false"
-    expected_error_msg = r"Command '\['false'\]' returned non-zero exit status 1. with stdout 'b''' and stderr 'b'''"
+    expected_error_msg = r"Command \['false'\] returned non-zero exit status 1\."
 
     # THEN
     with pytest.raises(CalledProcessError, match=expected_error_msg):
@@ -47,6 +48,43 @@ async def test_check_call_should_forward_args():
 
     # THEN
     assert await proc.stdout.read() == b"Hello World\n"
+
+
+async def test_called_process_error_formats_stderr_under_label(tmp_path):
+    with pytest.raises(FoxopsCalledProcessError) as exc_info:
+        await check_call("git", "status", cwd=tmp_path)
+
+    msg = str(exc_info.value)
+    assert "stderr:\n" in msg
+    assert "not a git repository" in msg
+
+
+async def test_called_process_error_formats_stdout_under_label(tmp_path):
+    # `git init` then force a push rejection so git writes to stdout
+    script = tmp_path / "fail.sh"
+    script.write_text("#!/bin/sh\necho 'output line'\nexit 1\n")
+    script.chmod(0o755)
+
+    with pytest.raises(FoxopsCalledProcessError) as exc_info:
+        await check_call(str(script))
+
+    msg = str(exc_info.value)
+    assert "stdout:\n" in msg
+    assert "output line" in msg
+
+
+def test_called_process_error_decodes_bytes():
+    err = FoxopsCalledProcessError(1, ["cmd"], b"out bytes", b"err bytes")
+    msg = str(err)
+    assert "stdout:\nout bytes" in msg
+    assert "stderr:\nerr bytes" in msg
+
+
+def test_called_process_error_omits_empty_sections():
+    err = FoxopsCalledProcessError(1, ["cmd"], b"", b"")
+    msg = str(err)
+    assert "stdout:" not in msg
+    assert "stderr:" not in msg
 
 
 async def test_check_call_should_kill_process_when_timeout_is_exceeded():


### PR DESCRIPTION
## Summary

- `CalledProcessError.__str__` previously printed stdout and stderr as raw bytes on a single line, making git errors hard to read
- Now decodes bytes and prints each stream under a labelled section (`stdout:` / `stderr:`), omitting sections that are empty
- Matches the readability of running git directly in a terminal

Closes #19

## Test plan

- `test_called_process_error_formats_stderr_under_label` — verifies stderr appears under `stderr:` label
- `test_called_process_error_formats_stdout_under_label` — verifies stdout appears under `stdout:` label
- `test_called_process_error_decodes_bytes` — verifies bytes are decoded to str
- `test_called_process_error_omits_empty_sections` — verifies empty stdout/stderr produce no label

🤖 Generated with [Claude Code](https://claude.com/claude-code)