### PR TITLE
feat: auto-update incarnations on a configurable interval

### DIFF
--- a/alembic/versions/2026_05_06-a1b2c3d4e5f6_add_auto_update_interval_to_incarnation.py
+++ b/alembic/versions/2026_05_06-a1b2c3d4e5f6_add_auto_update_interval_to_incarnation.py
@@ -1,0 +1,28 @@
+"""add auto_update_interval_seconds to incarnation
+
+Revision ID: a1b2c3d4e5f6
+Revises: 00ee97d0b7a3
+Create Date: 2026-05-06 00:00:00.000000+00:00
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "00ee97d0b7a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("incarnation", sa.Column("auto_update_interval_seconds", sa.Integer(), nullable=True))
+    op.execute("UPDATE incarnation SET auto_update_interval_seconds = 0")
+    with op.batch_alter_table("incarnation") as batch_op:
+        batch_op.alter_column("auto_update_interval_seconds", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("incarnation", "auto_update_interval_seconds")

--- a/src/foxops/__main__.py
+++ b/src/foxops/__main__.py
@@ -1,14 +1,23 @@
+import asyncio
+from contextlib import asynccontextmanager, suppress
+
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
-from foxops.dependencies import get_settings, static_token_auth_scheme
+from foxops.database.engine import create_engine
+from foxops.database.repositories.change.repository import ChangeRepository
+from foxops.database.repositories.incarnation.repository import IncarnationRepository
+from foxops.dependencies import build_hoster, get_settings, static_token_auth_scheme
 from foxops.error_handlers import __error_handlers__
 from foxops.logger import get_logger, setup_logging
 from foxops.middlewares import request_id_middleware, request_time_middleware
 from foxops.openapi import custom_openapi
 from foxops.routers import auth, incarnations, not_found, version
+from foxops.services.auto_update import AutoUpdateService
+from foxops.services.change import ChangeService
+from foxops.settings import DatabaseSettings
 
 #: Holds the module logger instance
 logger = get_logger(__name__)
@@ -19,11 +28,34 @@ logger = get_logger(__name__)
 FRONTEND_SUBDIRS = ["assets", "favicons"]
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    db_settings = DatabaseSettings()
+    engine = create_engine(db_settings.url.get_secret_value())
+    hoster = build_hoster(settings)
+    change_service = ChangeService(
+        hoster=hoster,
+        incarnation_repository=IncarnationRepository(engine),
+        change_repository=ChangeRepository(engine),
+    )
+    auto_update = AutoUpdateService(
+        change_service=change_service,
+        change_repository=ChangeRepository(engine),
+    )
+    task = asyncio.create_task(auto_update.run_loop())
+    yield
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+    await engine.dispose()
+
+
 def create_app():
     settings = get_settings()
     setup_logging(level=settings.log_level)
 
-    app = FastAPI()
+    app = FastAPI(lifespan=lifespan)
 
     # Add middlewares
     app.middleware("http")(request_id_middleware)

--- a/src/foxops/database/repositories/change/model.py
+++ b/src/foxops/database/repositories/change/model.py
@@ -48,6 +48,7 @@ class IncarnationWithChangesSummary(BaseModel):
     incarnation_repository: str
     target_directory: str
     template_repository: str
+    auto_update_interval_seconds: int
 
     revision: int
     type: ChangeType

--- a/src/foxops/database/repositories/change/repository.py
+++ b/src/foxops/database/repositories/change/repository.py
@@ -90,6 +90,7 @@ class ChangeRepository:
         requested_version: str,
         requested_data: str,
         template_data_full: str,
+        auto_update_interval_seconds: int = 0,
     ) -> ChangeInDB:
         logger = self.log.bind(function="create_incarnation_with_first_change")
         logger.debug(
@@ -106,6 +107,7 @@ class ChangeRepository:
                     incarnation_repository=incarnation_repository,
                     target_directory=target_directory,
                     template_repository=template_repository,
+                    auto_update_interval_seconds=auto_update_interval_seconds,
                 )
                 .returning(incarnations.c.id)
             )
@@ -193,6 +195,7 @@ class ChangeRepository:
                     incarnations.c.incarnation_repository,
                     incarnations.c.target_directory,
                     incarnations.c.template_repository,
+                    incarnations.c.auto_update_interval_seconds,
                     alias_change.c.revision,
                     alias_change.c.type,
                     alias_change.c.requested_version,

--- a/src/foxops/database/repositories/incarnation/model.py
+++ b/src/foxops/database/repositories/incarnation/model.py
@@ -6,4 +6,5 @@ class IncarnationInDB(BaseModel):
     incarnation_repository: str
     target_directory: str
     template_repository: str
+    auto_update_interval_seconds: int
     model_config = ConfigDict(from_attributes=True)

--- a/src/foxops/database/repositories/incarnation/repository.py
+++ b/src/foxops/database/repositories/incarnation/repository.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator
 
-from sqlalchemy import delete, insert, select
+from sqlalchemy import delete, insert, select, update
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -21,6 +21,7 @@ class IncarnationRepository:
         incarnation_repository: str,
         target_directory: str,
         template_repository: str,
+        auto_update_interval_seconds: int = 0,
     ) -> IncarnationInDB:
         async with self.engine.begin() as conn:
             query = (
@@ -29,6 +30,7 @@ class IncarnationRepository:
                     incarnation_repository=incarnation_repository,
                     target_directory=target_directory,
                     template_repository=template_repository,
+                    auto_update_interval_seconds=auto_update_interval_seconds,
                 )
                 .returning(incarnations)
             )
@@ -62,6 +64,15 @@ class IncarnationRepository:
                 raise IncarnationNotFoundError(f"could not find incarnation in DB with id: {id_}")
             else:
                 return IncarnationInDB.model_validate(row)
+
+    async def update_auto_update_interval(self, id_: int, interval_seconds: int) -> None:
+        query = (
+            update(incarnations).values(auto_update_interval_seconds=interval_seconds).where(incarnations.c.id == id_)
+        )
+        async with self.engine.begin() as conn:
+            result = await conn.execute(query)
+            if result.rowcount == 0:
+                raise IncarnationNotFoundError(f"could not find incarnation in DB with id: {id_}")
 
     async def delete_by_id(self, id_: int) -> None:
         query = delete(incarnations).where(incarnations.c.id == id_)

--- a/src/foxops/database/schema.py
+++ b/src/foxops/database/schema.py
@@ -20,6 +20,7 @@ incarnations = Table(
     Column("incarnation_repository", String, nullable=False),
     Column("target_directory", String, nullable=False),
     Column("template_repository", String, nullable=False),
+    Column("auto_update_interval_seconds", Integer, nullable=False, server_default="0"),
     UniqueConstraint("incarnation_repository", "target_directory", name="incarnation_identity"),
 )
 

--- a/src/foxops/dependencies.py
+++ b/src/foxops/dependencies.py
@@ -48,28 +48,27 @@ def get_database_engine(request: Request, settings: DatabaseSettings = Depends(g
     return async_engine
 
 
+def build_hoster(settings: Settings) -> Hoster:
+    match settings.hoster_type:
+        case HosterType.LOCAL:
+            local_settings = LocalHosterSettings()
+            logger.warning(
+                "Using local hoster. This is for DEVELOPMENT use only!", directory=str(local_settings.directory)
+            )
+            return LocalHoster(local_settings.directory)
+        case HosterType.GITLAB:
+            gitlab_settings = GitlabHosterSettings()
+            logger.info("Using GitLab hoster", address=gitlab_settings.address)
+            return GitlabHoster(gitlab_settings.address, gitlab_settings.token.get_secret_value())
+        case _:
+            raise NotImplementedError(f"Unknown hoster type {settings.hoster_type}")
+
+
 def get_hoster(request: Request, settings: Annotated[Settings, Depends(get_settings)]) -> Hoster:
     if hasattr(request.app.state, "hoster"):
         return request.app.state.hoster
 
-    hoster: Hoster
-    match settings.hoster_type:
-        case HosterType.LOCAL:
-            local_settings = LocalHosterSettings()
-
-            logger.warning(
-                "Using local hoster. This is for DEVELOPMENT use only!", directory=str(local_settings.directory)
-            )
-
-            hoster = LocalHoster(local_settings.directory)
-        case HosterType.GITLAB:
-            gitlab_settings = GitlabHosterSettings()
-            logger.info("Using GitLab hoster", address=gitlab_settings.address)
-
-            hoster = GitlabHoster(gitlab_settings.address, gitlab_settings.token.get_secret_value())
-        case _:
-            raise NotImplementedError(f"Unknown hoster type {settings.hoster_type}")
-
+    hoster = build_hoster(settings)
     request.app.state.hoster = hoster
     return hoster
 

--- a/src/foxops/models/incarnation.py
+++ b/src/foxops/models/incarnation.py
@@ -43,4 +43,6 @@ class IncarnationWithDetails(IncarnationBasic):
     template_data: TemplateData | None
     template_data_full: TemplateData | None
 
+    auto_update_interval_seconds: int
+
     model_config = ConfigDict(from_attributes=True)

--- a/src/foxops/routers/incarnations.py
+++ b/src/foxops/routers/incarnations.py
@@ -79,6 +79,8 @@ class CreateIncarnationRequest(BaseModel):
 
     template_data: TemplateData
 
+    auto_update_interval_seconds: int = 0
+
 
 @router.post(
     "",
@@ -122,6 +124,7 @@ async def create_incarnation(
             template_repository=request.template_repository,
             template_repository_version=request.template_repository_version,
             template_data=template_data,
+            auto_update_interval_seconds=request.auto_update_interval_seconds,
         )
     except ProvidedTemplateDataInvalidError as e:
         response.status_code = status.HTTP_400_BAD_REQUEST
@@ -281,6 +284,7 @@ class UpdateIncarnationRequest(BaseModel):
     template_data: TemplateData
 
     automerge: bool
+    auto_update_interval_seconds: int = 0
 
 
 @router.put(
@@ -321,7 +325,7 @@ async def update_incarnation(
     reusing the previously set variable values), use the PATCH endpoint instead.
     """
 
-    return await _create_change(
+    result = await _create_change(
         incarnation_id=incarnation_id,
         requested_version=request.template_repository_version,
         requested_data=request.template_data,
@@ -330,6 +334,9 @@ async def update_incarnation(
         response=response,
         change_service=change_service,
     )
+    if not isinstance(result, ApiError):
+        await change_service.set_auto_update_interval(incarnation_id, request.auto_update_interval_seconds)
+    return result
 
 
 class PatchIncarnationRequest(BaseModel):
@@ -339,6 +346,7 @@ class PatchIncarnationRequest(BaseModel):
     requested_data: TemplateData | None = None
 
     automerge: bool
+    auto_update_interval_seconds: int | None = None
 
     @model_validator(mode="after")
     def check_either_version_or_data_change_requested(self) -> Self:
@@ -387,7 +395,7 @@ async def patch_incarnation(
 
     requested_data = request.requested_data or {}
 
-    return await _create_change(
+    result = await _create_change(
         incarnation_id=incarnation_id,
         requested_version=request.requested_version,
         requested_data=requested_data,
@@ -396,6 +404,9 @@ async def patch_incarnation(
         response=response,
         change_service=change_service,
     )
+    if not isinstance(result, ApiError) and request.auto_update_interval_seconds is not None:
+        await change_service.set_auto_update_interval(incarnation_id, request.auto_update_interval_seconds)
+    return result
 
 
 @router.delete(

--- a/src/foxops/services/auto_update.py
+++ b/src/foxops/services/auto_update.py
@@ -1,0 +1,61 @@
+import asyncio
+from datetime import datetime, timezone
+
+from foxops.database.repositories.change.repository import ChangeRepository
+from foxops.logger import get_logger
+from foxops.services.change import (
+    ChangeRejectedDueToNoChanges,
+    ChangeRejectedDueToPreviousUnfinishedChange,
+    ChangeService,
+)
+
+logger = get_logger("auto_update")
+
+
+class AutoUpdateService:
+    def __init__(self, change_service: ChangeService, change_repository: ChangeRepository) -> None:
+        self._change_service = change_service
+        self._change_repository = change_repository
+        self._last_run: dict[int, datetime] = {}
+
+    async def run_once(self) -> None:
+        now = datetime.now(timezone.utc)
+        async for incarnation in self._change_repository.list_incarnations_with_changes_summary():
+            if incarnation.auto_update_interval_seconds == 0:
+                continue
+
+            last_run = self._last_run.get(incarnation.id, datetime.min.replace(tzinfo=timezone.utc))
+            elapsed = (now - last_run).total_seconds()
+            if elapsed < incarnation.auto_update_interval_seconds:
+                continue
+
+            log = logger.bind(
+                incarnation_id=incarnation.id,
+                incarnation_repository=incarnation.incarnation_repository,
+                target_directory=incarnation.target_directory,
+                requested_version=incarnation.requested_version,
+            )
+            try:
+                await self._change_service.create_change_merge_request(
+                    incarnation_id=incarnation.id,
+                    requested_version=incarnation.requested_version,
+                    requested_data={},
+                    automerge=True,
+                    patch=True,
+                )
+                log.info("auto-update triggered")
+            except ChangeRejectedDueToNoChanges:
+                log.debug("auto-update: already up to date")
+            except ChangeRejectedDueToPreviousUnfinishedChange:
+                log.debug("auto-update: previous change still in progress, will retry")
+                continue
+            except Exception:
+                log.exception("auto-update failed")
+                continue
+
+            self._last_run[incarnation.id] = now
+
+    async def run_loop(self, tick_seconds: int = 60) -> None:
+        while True:
+            await self.run_once()
+            await asyncio.sleep(tick_seconds)

--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -58,6 +58,7 @@ class IncarnationWithLatestChangeDetails(BaseModel):
     incarnation_repository: str
     target_directory: str
     template_repository: str
+    auto_update_interval_seconds: int
 
     revision: int
     type: ChangeType
@@ -137,6 +138,7 @@ class ChangeService:
             incarnation_repository=dbobj.incarnation_repository,
             target_directory=dbobj.target_directory,
             template_repository=dbobj.template_repository,
+            auto_update_interval_seconds=dbobj.auto_update_interval_seconds,
             revision=dbobj.revision,
             type=dbobj.type,
             requested_version=dbobj.requested_version,
@@ -153,6 +155,9 @@ class ChangeService:
             async for inc in self._change_repository.list_incarnations_with_changes_summary()
         ]
 
+    async def set_auto_update_interval(self, incarnation_id: int, interval_seconds: int) -> None:
+        await self._incarnation_repository.update_auto_update_interval(incarnation_id, interval_seconds)
+
     async def get_incarnation_by_repo_and_target_directory(
         self, repo: str, target_directory: str
     ) -> IncarnationWithLatestChangeDetails:
@@ -167,6 +172,7 @@ class ChangeService:
         template_repository_version: str,
         template_data: TemplateData,
         target_directory: str = ".",
+        auto_update_interval_seconds: int = 0,
     ) -> Change:
         if await self._hoster.get_incarnation_state(incarnation_repository, target_directory) is not None:
             raise IncarnationAlreadyExists("Cannot create incarnation because it already exists")
@@ -198,6 +204,7 @@ class ChangeService:
                 requested_version=template_repository_version,
                 requested_data=json.dumps(incarnation_state.template_data),
                 template_data_full=json.dumps(incarnation_state.template_data_full),
+                auto_update_interval_seconds=auto_update_interval_seconds,
             )
 
             try:
@@ -584,6 +591,7 @@ class ChangeService:
             template_repository_version_hash=change.requested_version_hash,
             template_data=change.requested_data,
             template_data_full=change.template_data_full,
+            auto_update_interval_seconds=incarnation.auto_update_interval_seconds,
         )
 
     async def diff_incarnation(self, incarnation_id: int) -> str:

--- a/tests/database/test_incarnation_repository.py
+++ b/tests/database/test_incarnation_repository.py
@@ -65,6 +65,7 @@ async def test_get_by_id_returns_existing_incarnation(
         incarnation_repository="incarnation_repo",
         target_directory="test",
         template_repository="template_repo",
+        auto_update_interval_seconds=0,
     )
 
 

--- a/tests/routers/test_incarnations.py
+++ b/tests/routers/test_incarnations.py
@@ -41,6 +41,7 @@ class ChangeServiceMock(Mock):
         template_repository_version: str,
         template_data: dict[str, str],
         target_directory: str = ".",
+        auto_update_interval_seconds: int = 0,
     ) -> Change:
         return Change(
             id=1,
@@ -120,6 +121,7 @@ async def test_api_get_incarnations_returns_incarnations_from_inventory(
             "requested_version": "v1.0",
             "revision": 1,
             "type": "direct",
+            "auto_update_interval_seconds": 0,
         }
     ]
 

--- a/tests/services/test_auto_update.py
+++ b/tests/services/test_auto_update.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from foxops.database.repositories.change.model import (
+    ChangeType,
+    IncarnationWithChangesSummary,
+)
+from foxops.services.auto_update import AutoUpdateService
+from foxops.services.change import (
+    ChangeRejectedDueToNoChanges,
+    ChangeRejectedDueToPreviousUnfinishedChange,
+)
+
+
+def _make_incarnation(
+    id: int = 1,
+    auto_update_interval_seconds: int = 3600,
+    requested_version: str = "main",
+) -> IncarnationWithChangesSummary:
+    return IncarnationWithChangesSummary(
+        id=id,
+        incarnation_repository="repo/incarnation",
+        target_directory=".",
+        template_repository="repo/template",
+        auto_update_interval_seconds=auto_update_interval_seconds,
+        revision=1,
+        type=ChangeType.DIRECT,
+        commit_sha="abc123",
+        requested_version=requested_version,
+        merge_request_id=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def _as_async_iter(items):
+    for item in items:
+        yield item
+
+
+@pytest.fixture
+def change_service():
+    svc = MagicMock()
+    svc.create_change_merge_request = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def change_repository():
+    repo = MagicMock()
+    return repo
+
+
+@pytest.fixture
+def auto_update_service(change_service, change_repository):
+    return AutoUpdateService(change_service=change_service, change_repository=change_repository)
+
+
+async def test_skips_incarnation_with_zero_interval(auto_update_service, change_service, change_repository):
+    incarnation = _make_incarnation(auto_update_interval_seconds=0)
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+
+    await auto_update_service.run_once()
+
+    change_service.create_change_merge_request.assert_not_called()
+
+
+async def test_skips_incarnation_not_yet_due(auto_update_service, change_service, change_repository):
+    incarnation = _make_incarnation(auto_update_interval_seconds=3600)
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+    # Record a last_run that is only 10 seconds ago
+    auto_update_service._last_run[incarnation.id] = datetime.now(timezone.utc) - timedelta(seconds=10)
+
+    await auto_update_service.run_once()
+
+    change_service.create_change_merge_request.assert_not_called()
+
+
+async def test_triggers_change_for_due_incarnation(auto_update_service, change_service, change_repository):
+    incarnation = _make_incarnation(auto_update_interval_seconds=3600, requested_version="main")
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+    # Never run before — last_run defaults to epoch, so it's always due
+
+    await auto_update_service.run_once()
+
+    change_service.create_change_merge_request.assert_awaited_once_with(
+        incarnation_id=incarnation.id,
+        requested_version="main",
+        requested_data={},
+        automerge=True,
+        patch=True,
+    )
+
+
+async def test_updates_last_run_after_successful_change(auto_update_service, change_service, change_repository):
+    incarnation = _make_incarnation(auto_update_interval_seconds=3600)
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+
+    before = datetime.now(timezone.utc)
+    await auto_update_service.run_once()
+    after = datetime.now(timezone.utc)
+
+    last_run = auto_update_service._last_run[incarnation.id]
+    assert before <= last_run <= after
+
+
+async def test_updates_last_run_when_no_changes(auto_update_service, change_service, change_repository):
+    incarnation = _make_incarnation(auto_update_interval_seconds=3600)
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+    change_service.create_change_merge_request.side_effect = ChangeRejectedDueToNoChanges()
+
+    await auto_update_service.run_once()
+
+    assert incarnation.id in auto_update_service._last_run
+
+
+async def test_does_not_update_last_run_when_previous_change_unfinished(
+    auto_update_service, change_service, change_repository
+):
+    incarnation = _make_incarnation(auto_update_interval_seconds=3600)
+    change_repository.list_incarnations_with_changes_summary = MagicMock(return_value=_as_async_iter([incarnation]))
+    change_service.create_change_merge_request.side_effect = ChangeRejectedDueToPreviousUnfinishedChange()
+
+    await auto_update_service.run_once()
+
+    assert incarnation.id not in auto_update_service._last_run

--- a/ui/src/interfaces/incarnations.types.ts
+++ b/ui/src/interfaces/incarnations.types.ts
@@ -48,6 +48,7 @@ export interface IncarnationApiView {
   template_repository_version_hash: string
   template_data: Record<string, string> | null,
   template_data_full: Record<string, never> | null,
+  auto_update_interval_seconds: number,
 }
 
 export interface ChangeApiView {
@@ -102,13 +103,15 @@ export interface Incarnation {
   templateRepositoryVersion: string,
   templateRepositoryVersionHash: string,
   templateData: Record<string, string>,
-  templateDataFull: Record<string, never>
+  templateDataFull: Record<string, never>,
+  autoUpdateIntervalSeconds: number,
 }
 
 export interface IncarnationUpdateApiInput {
   template_repository_version: string,
   template_data: Record<string, string>,
-  automerge: boolean
+  automerge: boolean,
+  auto_update_interval_seconds: number,
 }
 
 export interface IncarnationApiInput {
@@ -117,5 +120,6 @@ export interface IncarnationApiInput {
   template_repository_version: string,
   target_directory: string,
   template_data: Record<string, string>,
-  automerge: boolean
+  automerge: boolean,
+  auto_update_interval_seconds: number,
 }

--- a/ui/src/routes/incarnations/CreateForm.tsx
+++ b/ui/src/routes/incarnations/CreateForm.tsx
@@ -3,6 +3,7 @@ import { IncarnationsForm } from './Form'
 
 const defaultValues = {
   automerge: true,
+  autoUpdateIntervalSeconds: 0,
   repository: '',
   targetDirectory: '',
   templateRepository: '',

--- a/ui/src/routes/incarnations/EditForm.tsx
+++ b/ui/src/routes/incarnations/EditForm.tsx
@@ -11,6 +11,7 @@ import { Incarnation } from '../../interfaces/incarnations.types'
 
 const toIncarnationInput = (x: Incarnation): IncarnationInput => ({
   automerge: true,
+  autoUpdateIntervalSeconds: x.autoUpdateIntervalSeconds,
   repository: x.incarnationRepository,
   targetDirectory: x.targetDirectory,
   templateRepository: x.templateRepository ?? '',

--- a/ui/src/routes/incarnations/Form.tsx
+++ b/ui/src/routes/incarnations/Form.tsx
@@ -337,10 +337,9 @@ export const IncarnationsForm = ({
                   render={({ field: { onChange, value } }) => (
                     <TextField
                       label="Update interval (minutes)"
-                      type="number"
                       disabled={isLoading}
                       size="large"
-                      value={Math.round(value / 60)}
+                      value={String(Math.round(value / 60))}
                       onChange={e => onChange(Math.max(1, parseInt(e.target.value, 10) || 1) * 60)}
                     />
                   )}

--- a/ui/src/routes/incarnations/Form.tsx
+++ b/ui/src/routes/incarnations/Form.tsx
@@ -315,6 +315,38 @@ export const IncarnationsForm = ({
                 />
               </Hug>
             )}
+            <Hug mb={16}>
+              <Controller
+                control={control}
+                name="autoUpdateIntervalSeconds"
+                render={({ field: { onChange, value } }) => (
+                  <ToggleSwitch
+                    checked={value > 0}
+                    label="Auto update"
+                    disabled={isLoading}
+                    onChange={e => onChange(e.target.checked ? 3600 : 0)}
+                  />
+                )}
+              />
+            </Hug>
+            {watch('autoUpdateIntervalSeconds') > 0 && (
+              <Hug mb={16}>
+                <Controller
+                  control={control}
+                  name="autoUpdateIntervalSeconds"
+                  render={({ field: { onChange, value } }) => (
+                    <TextField
+                      label="Update interval (minutes)"
+                      type="number"
+                      disabled={isLoading}
+                      size="large"
+                      value={Math.round(value / 60)}
+                      onChange={e => onChange(Math.max(1, parseInt(e.target.value, 10) || 1) * 60)}
+                    />
+                  )}
+                />
+              </Hug>
+            )}
           </Hug>
           <Hug w="calc(60% - 2rem)" h="100%">
             {isEdit ? (

--- a/ui/src/services/incarnations.ts
+++ b/ui/src/services/incarnations.ts
@@ -121,7 +121,8 @@ export const incarnations = {
     const incarnationApiInput: IncarnationUpdateApiInput = {
       automerge: input.automerge,
       template_repository_version: input.templateVersion,
-      template_data: incarnation.templateData
+      template_data: incarnation.templateData,
+      auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds
     }
     const data = await api.put<IncarnationUpdateApiInput, IncarnationApiView>(`/incarnations/${incarnation.id}`, { body: incarnationApiInput })
     return convertToUiIncarnation(data)

--- a/ui/src/services/incarnations.ts
+++ b/ui/src/services/incarnations.ts
@@ -20,6 +20,7 @@ export const INCARNATION_SEARCH_FIELDS: (keyof IncarnationBase)[] = [
 
 export interface IncarnationInput {
   automerge: boolean,
+  autoUpdateIntervalSeconds: number,
   repository: string,
   targetDirectory: string,
   templateRepository: string,
@@ -30,6 +31,7 @@ export interface IncarnationInput {
 export interface IncarnationUpdateInput {
   templateVersion: string,
   automerge: boolean,
+  autoUpdateIntervalSeconds: number,
   templateData: string
 }
 
@@ -65,7 +67,8 @@ const convertToUiIncarnation = (incarnation: IncarnationApiView): Incarnation =>
   templateRepositoryVersionHash: incarnation.template_repository_version_hash,
   templateData: incarnation.template_data ?? {},
   templateDataFull: incarnation.template_data_full ?? {},
-  revision: incarnation.revision
+  revision: incarnation.revision,
+  autoUpdateIntervalSeconds: incarnation.auto_update_interval_seconds,
 })
 
 const convertToApiInput = (incarnation: IncarnationInput): IncarnationApiInput => ({
@@ -74,13 +77,15 @@ const convertToApiInput = (incarnation: IncarnationInput): IncarnationApiInput =
   template_repository_version: incarnation.templateVersion,
   target_directory: incarnation.targetDirectory,
   template_data: JSON.parse(incarnation.templateData),
-  automerge: false
+  automerge: false,
+  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds,
 })
 
 const convertToApiUpdateInput = (incarnation: IncarnationInput): IncarnationUpdateApiInput => ({
   template_repository_version: incarnation.templateVersion,
   template_data: JSON.parse(incarnation.templateData),
-  automerge: incarnation.automerge
+  automerge: incarnation.automerge,
+  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds,
 })
 
 const convertToUiChange = (incarnationChange: ChangeApiView): Change => ({

--- a/ui/src/services/incarnations.ts
+++ b/ui/src/services/incarnations.ts
@@ -68,7 +68,7 @@ const convertToUiIncarnation = (incarnation: IncarnationApiView): Incarnation =>
   templateData: incarnation.template_data ?? {},
   templateDataFull: incarnation.template_data_full ?? {},
   revision: incarnation.revision,
-  autoUpdateIntervalSeconds: incarnation.auto_update_interval_seconds,
+  autoUpdateIntervalSeconds: incarnation.auto_update_interval_seconds
 })
 
 const convertToApiInput = (incarnation: IncarnationInput): IncarnationApiInput => ({
@@ -78,14 +78,14 @@ const convertToApiInput = (incarnation: IncarnationInput): IncarnationApiInput =
   target_directory: incarnation.targetDirectory,
   template_data: JSON.parse(incarnation.templateData),
   automerge: false,
-  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds,
+  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds
 })
 
 const convertToApiUpdateInput = (incarnation: IncarnationInput): IncarnationUpdateApiInput => ({
   template_repository_version: incarnation.templateVersion,
   template_data: JSON.parse(incarnation.templateData),
   automerge: incarnation.automerge,
-  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds,
+  auto_update_interval_seconds: incarnation.autoUpdateIntervalSeconds
 })
 
 const convertToUiChange = (incarnationChange: ChangeApiView): Change => ({


### PR DESCRIPTION
NB: Speculative feature, not worth reviewing yet.

## Summary

- Adds `auto_update_interval_seconds` (integer, 0 = disabled) to the `incarnation` table, with a DB migration. No separate boolean needed — zero means off.
- `AutoUpdateService` runs as an asyncio background task (started via a FastAPI lifespan handler). Each tick (60 s) it checks every incarnation whose interval has elapsed and calls `create_change_merge_request` with `automerge=True, patch=True`, targeting the latest commit on the incarnation's current branch or tag. Already-up-to-date and in-progress cases are handled gracefully.
- The interval is exposed on all create/update/patch API endpoints and all response models.
- The UI gains an **Auto update** toggle and an **Update interval (minutes)** input in the incarnation form, converting to/from seconds at the API boundary.

## Test plan

- [ ] `poetry run pytest tests/services/test_auto_update.py` — 6 unit tests covering: interval=0 skip, not-yet-due skip, due incarnation triggers change with correct args, `ChangeRejectedDueToNoChanges` swallowed and last-run updated, `ChangeRejectedDueToPreviousUnfinishedChange` does not update last-run
- [ ] `poetry run pytest` — full suite passes
- [ ] Manual: create an incarnation pointing to a branch, enable auto-update with a short interval, push a commit to the template branch, confirm an MR appears within one tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)