### PR TITLE
feat: build multi-arch image (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/roche/foxops:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ (github.event.pull_request.head.repo.full_name == github.repository) || (github.ref == 'refs/heads/main') }}
           tags: |
             ghcr.io/roche/foxops:${{ github.sha }}


### PR DESCRIPTION
## Summary

- Adds `platforms: linux/amd64,linux/arm64` to the `build-push-action` step in both `ci.yml` and `cd.yml`.
- QEMU and Buildx were already configured in both workflows; this is the only change required.
- The base images used (`python:3.12-slim`, `node:lts-alpine`) both publish arm64 variants, so no Dockerfile changes are needed.

## Test plan

- [ ] CI `container` job passes on this PR — arm64 layer is built via QEMU emulation and the multi-arch manifest is pushed to GHCR.
- [ ] Verify the pushed manifest includes both architectures: `docker buildx imagetools inspect ghcr.io/roche/foxops:<sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)