### PR TITLE
fix: unique foxops branch names to prevent stale branch collisions

### DIFF
--- a/src/foxops/services/change.py
+++ b/src/foxops/services/change.py
@@ -823,4 +823,5 @@ def delete_all_files_in_local_git_repository(directory: Path) -> None:
 
 def generate_foxops_branch_name(prefix: str, target_directory: str, template_repository_version: str) -> str:
     target_directory_hash = hashlib.sha1(target_directory.encode("utf-8")).hexdigest()[:7]
-    return f"foxops/{prefix}-{target_directory_hash}-{template_repository_version}"
+    unique_suffix = uuid.uuid4().hex[:8]
+    return f"foxops/{prefix}-{target_directory_hash}-{template_repository_version}-{unique_suffix}"


### PR DESCRIPTION
## Summary

- Branch names for MR changes are deterministic: `foxops/update-to-{hash}-{version}`. When an MR is closed without merging, the source branch persists on the remote. A subsequent update to the same version generates the same name, causing a push failure with `RebaseRequiredError`.
- Adds a short uuid suffix to the branch name, preventing collisions without requiring branch deletion API calls.

Related to #584 (root cause 2: stale branch scenario).

