### PR TITLE
fix: Modified incarnation report deletion conflict

### DIFF
--- a/src/foxops/engine/patching/git_diff_patch.py
+++ b/src/foxops/engine/patching/git_diff_patch.py
@@ -218,12 +218,15 @@ def parse_git_apply_rejection_output(output: bytes) -> PatchResult:
                     The returned paths are relative to the repository root.
     """
     reject_file_regex = re.compile(rb"Applying patch (.*?) with (\d+) reject...")
+    unapplied_file_regex = re.compile(rb"error: (.*): patch does not apply")
     deleted_target_regex = re.compile(rb"error: (.*): No such file or directory")
 
     files_with_rejections = []
     deleted_target_files = []
     for line in output.splitlines():
         if match := reject_file_regex.match(line):
+            files_with_rejections.append(Path(match.group(1).decode()))
+        if match := unapplied_file_regex.match(line):
             files_with_rejections.append(Path(match.group(1).decode()))
         if match := deleted_target_regex.match(line):
             deleted_target_files.append(Path(match.group(1).decode()))

--- a/tests/e2e/assertions.py
+++ b/tests/e2e/assertions.py
@@ -63,7 +63,10 @@ def assert_update_merge_request_exists(
 
 
 def assert_update_merge_request_with_conflicts_exists(
-    gitlab_client: Client, repository: str, files_with_conflicts: list[str]
+    gitlab_client: Client,
+    repository: str,
+    files_with_conflicts: list[str],
+    files_with_rejections: list[str],
 ):
     params = {"state": "opened", "target_branch": "main"}
     response = gitlab_client.get(f"/projects/{quote_plus(repository)}/merge_requests", params=params)
@@ -84,7 +87,7 @@ def assert_update_merge_request_with_conflicts_exists(
 
     changes = response.json()["changes"]
 
-    for f in files_with_conflicts:
+    for f in files_with_rejections:
         assert any(
             c["new_path"] == f"{f}.rej" and c["new_file"] for c in changes
         ), f"No rejection file found for file {f}. Changes: {changes}. Merge request: {merge_request}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,6 +18,80 @@ TemplateVersion = NamedTuple(
 )
 
 TemplateFactory = Callable[[list[TemplateVersion]], str]
+TemplateVersionFactory = Callable[[str, TemplateVersion, TemplateVersion], None]
+RepositoryFileUpdater = Callable[[str, str, bytes], None]
+
+
+@pytest.fixture(scope="session")
+def gitlab_template_version_factory(gitlab_client: Client) -> TemplateVersionFactory:
+    def _add_version(repository: str, previous_version: TemplateVersion, version: TemplateVersion) -> None:
+        project = quote_plus(repository)
+        response = gitlab_client.get(f"/projects/{project}")
+        response.raise_for_status()
+        branch = response.json()["default_branch"]
+
+        if previous_version.config != version.config:
+            response = gitlab_client.put(
+                f"/projects/{project}/repository/files/{quote_plus('fengine.yaml')}",
+                json={
+                    "encoding": "base64",
+                    "content": base64.b64encode(version.config.yaml().encode()).decode(),
+                    "commit_message": f"Configure template {version.version}",
+                    "branch": branch,
+                },
+            )
+            response.raise_for_status()
+
+        for path in previous_version.files.keys() - version.files.keys():
+            response = gitlab_client.request(
+                "DELETE",
+                f"/projects/{project}/repository/files/{quote_plus('template/' + path)}",
+                json={
+                    "commit_message": f"Delete {path} in {version.version}",
+                    "branch": branch,
+                },
+            )
+            response.raise_for_status()
+
+        for path, content in version.files.items():
+            if previous_version.files.get(path) == content:
+                continue
+            file_method = gitlab_client.put if path in previous_version.files else gitlab_client.post
+            response = file_method(
+                f"/projects/{project}/repository/files/{quote_plus('template/' + path)}",
+                json={
+                    "encoding": "base64",
+                    "content": base64.b64encode(content).decode(),
+                    "commit_message": f"Update {path} for {version.version}",
+                    "branch": branch,
+                },
+            )
+            response.raise_for_status()
+
+        response = gitlab_client.post(
+            f"/projects/{project}/repository/tags",
+            json={"tag_name": version.version, "ref": branch},
+        )
+        response.raise_for_status()
+
+    return _add_version
+
+
+@pytest.fixture
+def gitlab_repository_file_updater(gitlab_client: Client) -> RepositoryFileUpdater:
+    def _update(repository: str, path: str, content: bytes) -> None:
+        response = gitlab_client.put(
+            f"/projects/{quote_plus(repository)}/repository/files/{quote_plus(path)}",
+            json={
+                "encoding": "base64",
+                "content": base64.b64encode(content).decode(),
+                "commit_message": f"Modify {path} in incarnation",
+                "branch": "main",
+            },
+        )
+        response.raise_for_status()
+
+    return _update
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_incarnations_api.py
+++ b/tests/e2e/test_incarnations_api.py
@@ -406,6 +406,79 @@ async def test_put_incarnation_creates_merge_request_with_conflicts(
         gitlab_client,
         incarnation_repository,
         files_with_conflicts=["README.md"],
+        files_with_rejections=["README.md"],
+    )
+
+
+async def test_put_incarnation_reports_conflict_when_modified_file_is_deleted_from_template(
+    foxops_client: AsyncClient,
+    gitlab_client: Client,
+    gitlab_project_factory: Callable[[str], dict],
+    gitlab_template_factory,
+    gitlab_template_version_factory,
+    gitlab_repository_file_updater,
+):
+    template_config = TemplateConfig()
+    previous_template_version = TemplateVersion(
+        version="v1.0.0",
+        config=template_config,
+        files={"README.md": b"template content"},
+    )
+    template_repository = gitlab_template_factory([previous_template_version])
+    updated_template_version = TemplateVersion(
+        version="v2.0.0",
+        config=template_config,
+        files={},
+    )
+    incarnation_repository = gitlab_project_factory("incarnation")["path_with_namespace"]
+    response = await foxops_client.post(
+        "/api/incarnations",
+        json={
+            "incarnation_repository": incarnation_repository,
+            "template_repository": template_repository,
+            "template_repository_version": "v1.0.0",
+            "template_data": {},
+        },
+    )
+    response.raise_for_status()
+    incarnation_id = response.json()["id"]
+
+    gitlab_repository_file_updater(
+        incarnation_repository,
+        "README.md",
+        b"locally modified content",
+    )
+    gitlab_template_version_factory(
+        template_repository,
+        previous_template_version,
+        updated_template_version,
+    )
+
+    response = await foxops_client.put(
+        f"/api/incarnations/{incarnation_id}",
+        json={
+            "template_repository_version": "v2.0.0",
+            "template_data": {},
+            "automerge": True,
+        },
+    )
+    response.raise_for_status()
+
+    incarnation = response.json()
+    assert incarnation["status"] == "pending"
+    assert incarnation["merge_request_status"] == "open"
+    conflict_branch = assert_update_merge_request_with_conflicts_exists(
+        gitlab_client,
+        incarnation_repository,
+        files_with_conflicts=["README.md"],
+        files_with_rejections=[],
+    )
+    assert_file_in_repository(
+        gitlab_client,
+        incarnation_repository,
+        "README.md",
+        "locally modified content",
+        branch=conflict_branch,
     )
 
 

--- a/tests/engine/test_update.py
+++ b/tests/engine/test_update.py
@@ -382,6 +382,7 @@ mychange
 """
 
 
+# Unmodified file gets deleted properly
 @pytest.mark.parametrize("diff_patch_func", [diff_and_patch])
 async def test_diff_and_patch_success_when_deleting_file_in_template(
     diff_patch_func,
@@ -433,6 +434,31 @@ async def test_diff_and_patch_success_when_deleting_file_in_template(
     # THEN
     assert (incarnation_directory / "myfile1.txt").exists()
     assert not (incarnation_directory / "myfile2.txt").exists()
+
+
+# Modified file gets a conflict upon deletion
+@pytest.mark.parametrize("diff_patch_func", [diff_and_patch])
+async def test_diff_and_patch_conflict_when_deleting_modified_file_in_template(diff_patch_func, tmp_path):
+    old_directory = tmp_path / "old"
+    old_directory.mkdir()
+    (old_directory / "file.txt").write_text("template content")
+    (old_directory / "unchanged.txt").write_text("unchanged")
+    new_directory = tmp_path / "new"
+    shutil.copytree(old_directory, new_directory)
+    (new_directory / "file.txt").unlink()
+    incarnation_directory = tmp_path / "incarnation"
+    shutil.copytree(old_directory, incarnation_directory)
+    (incarnation_directory / "file.txt").write_text("locally modified content")
+    await init_repository(incarnation_directory)
+
+    patch_result = await diff_patch_func(
+        diff_a_directory=old_directory,
+        diff_b_directory=new_directory,
+        patch_directory=incarnation_directory,
+    )
+
+    assert patch_result.conflicts == [Path("file.txt")]
+    assert (incarnation_directory / "file.txt").read_text() == "locally modified content"
 
 
 @pytest.mark.parametrize("diff_patch_func", [diff_and_patch])


### PR DESCRIPTION
foxops silently drops template deletions of locally-modified files If a file was edited in an incarnation and later deleted in the template: 
FoxOps keeps the local copy and never flags it as a conflict, (not even inside a ":construction: CONFLICT" MR)

It only surfaces modify/modify conflicts; modify/delete losses are silent. Result: clusters stay on versions that already removed a file, yet still carry it.

This is a problem, as it leads to a drift.

This fixes it by:
- increasing the test coverage to guarantee that incaranation modified files are triggering a conflict upon their template's deletion
- engine is raising the right signal in git diff patch.

Here is an example of the git apply --reject for an updated file that got deleted in a template:

```
$ git apply --reject ../patch
Checking patch README.md...
error: while searching for:
CONTENT

error: patch failed: README.md:1
error: removal patch leaves file contents
error: README.md: patch does not apply
Checking patch todo...
Applied patch todo cleanly.
```

Which you can see the new "patch does not apply" line. This works as git version 2.55.

However, this does NOT update the function to be more resilient to any future git operation message change.