### PR TITLE
chore: Cleanup dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,4 +41,6 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,31 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies for poetry
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
Without this, you get large amount of PRs for bumps that are hanging around and not merged.

<img width="1106" height="1228" alt="image" src="https://github.com/user-attachments/assets/8ef7eac8-d12a-4741-9615-cb671c4c6362" />

This is fine for fine grained dependencies and for dependency management, but has a limit in terms of reviewer's time.

A few symptoms usually appear:
- reviewers start to blindly approve
- reviewers do not approve the changes together (hope that independent bumps are not impacting other bumps)
- reviewers leave some changes hanging ("it's fine, there will be another bump soon!")

This fixes it by reducing the amount of PRs to 1 per type of bump, every week, with _everything included in one swoop_ (solving the independent incompatible bumps).

This also adds a _cooldown period_ which will reduce the risk of supply chain attacks not handled (in a case where a bad version is proposed, merged, then no update got merged for a while).

In other words: With this PR, a rythm of a _one PR per ecosystem per week_ starts to appear. If you follow the rhythm, you will only be a week behind in dependencies (cooldown) which is enough for avoiding many supply chain attacks while not staying too long without security fixes.