### PR TITLE
test: reduce GitLab Puma memory use

### DIFF
--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -8,6 +8,7 @@ services:
       GITLAB_ROOT_PASSWORD: ${GITLAB_ROOT_PASSWORD}
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://127.0.0.1:8929'
+        puma['worker_processes'] = 0
     volumes:
       - config-ce:/etc/gitlab
       - logs-ce:/var/log/gitlab


### PR DESCRIPTION
Puma reconfiguration cause temporary issues, documented in [1]. We do not need reconfiguration during CI.

Closes: #628

[1]: https://federal-support.gitlab.com/hc/en-us/articles/40212946732692-Frequent-502-Errors-and-Restarts-Due-to-Puma-Single-Mode-Configuration